### PR TITLE
Remove 'WsCallback' warning

### DIFF
--- a/fixposition_driver_ros1/src/fixposition_driver_node.cpp
+++ b/fixposition_driver_ros1/src/fixposition_driver_node.cpp
@@ -159,7 +159,6 @@ void FixpositionDriverNode::Run() {
 }
 
 void FixpositionDriverNode::WsCallback(const fixposition_driver_ros1::SpeedConstPtr& msg) {
-    ROS_WARN("WsCallback");
     FixpositionDriver::WsCallback(msg->speeds);
 }
 


### PR DESCRIPTION
I am seeing an endless stream of `WsCallback` warning messages. Since the message doesn't carry any meaning (the text doesn't explain what the warning is about) I propose to remove this log message.