### PR TITLE
Improve compatibility with ROS2 distros

### DIFF
--- a/fixposition_driver_ros2/CMakeLists.txt
+++ b/fixposition_driver_ros2/CMakeLists.txt
@@ -50,32 +50,12 @@ add_executable(
   src/data_to_ros2.cpp
 )
 
-if($ENV{ROS_DISTRO} MATCHES "humble")
+if($ENV{ROS_DISTRO} MATCHES "humble|rolling")
   rosidl_get_typesupport_target(
     cpp_typesupport_target
     ${PROJECT_NAME} "rosidl_typesupport_cpp"
   )
-elseif($ENV{ROS_DISTRO} MATCHES "rolling")
-  rosidl_get_typesupport_target(
-    cpp_typesupport_target
-    ${PROJECT_NAME} "rosidl_typesupport_cpp"
-  )
-elseif($ENV{ROS_DISTRO} MATCHES "galactic")
-  rosidl_target_interfaces(
-    ${PROJECT_NAME}_exec
-    ${PROJECT_NAME} "rosidl_typesupport_cpp"
-  )
-elseif($ENV{ROS_DISTRO} MATCHES "foxy")
-  rosidl_target_interfaces(
-    ${PROJECT_NAME}_exec
-    ${PROJECT_NAME} "rosidl_typesupport_cpp"
-  )
-elseif($ENV{ROS_DISTRO} MATCHES "eloquent")
-  rosidl_target_interfaces(
-    ${PROJECT_NAME}_exec
-    ${PROJECT_NAME} "rosidl_typesupport_cpp"
-  )
-elseif($ENV{ROS_DISTRO} MATCHES "dashing")
+elseif($ENV{ROS_DISTRO} MATCHES "galactic|foxy|eloquent|dashing")
   rosidl_target_interfaces(
     ${PROJECT_NAME}_exec
     ${PROJECT_NAME} "rosidl_typesupport_cpp"

--- a/fixposition_driver_ros2/CMakeLists.txt
+++ b/fixposition_driver_ros2/CMakeLists.txt
@@ -50,10 +50,39 @@ add_executable(
   src/data_to_ros2.cpp
 )
 
-rosidl_target_interfaces(
-  ${PROJECT_NAME}_exec
-  ${PROJECT_NAME} "rosidl_typesupport_cpp"
-)
+if($ENV{ROS_DISTRO} MATCHES "humble")
+  rosidl_get_typesupport_target(
+    cpp_typesupport_target
+    ${PROJECT_NAME} "rosidl_typesupport_cpp"
+  )
+elseif($ENV{ROS_DISTRO} MATCHES "rolling")
+  rosidl_get_typesupport_target(
+    cpp_typesupport_target
+    ${PROJECT_NAME} "rosidl_typesupport_cpp"
+  )
+elseif($ENV{ROS_DISTRO} MATCHES "galactic")
+  rosidl_target_interfaces(
+    ${PROJECT_NAME}_exec
+    ${PROJECT_NAME} "rosidl_typesupport_cpp"
+  )
+elseif($ENV{ROS_DISTRO} MATCHES "foxy")
+  rosidl_target_interfaces(
+    ${PROJECT_NAME}_exec
+    ${PROJECT_NAME} "rosidl_typesupport_cpp"
+  )
+elseif($ENV{ROS_DISTRO} MATCHES "eloquent")
+  rosidl_target_interfaces(
+    ${PROJECT_NAME}_exec
+    ${PROJECT_NAME} "rosidl_typesupport_cpp"
+  )
+elseif($ENV{ROS_DISTRO} MATCHES "dashing")
+  rosidl_target_interfaces(
+    ${PROJECT_NAME}_exec
+    ${PROJECT_NAME} "rosidl_typesupport_cpp"
+  )
+else()
+  message(FATAL_ERROR "Unsupported ROS_DISTRO")
+endif()
 
 target_link_libraries(
   ${PROJECT_NAME}_exec


### PR DESCRIPTION
Current build on humble yields a deprecation warning [seen here](https://github.com/fixposition/fixposition_driver/actions/runs/4738633288/jobs/8412699218). Latest [ROS2 Humble (> Nov 2022)](https://github.com/ros2/ros2/pull/1350) employs [`rosidl=3.1.4`](https://github.com/ros2/rosidl/blob/3.1.4/rosidl_cmake/cmake/rosidl_target_interfaces.cmake#L55) which currently handles the issue raised in the warning. However, older Humble versions produce build errors. This change incorporates the warning suggestion for improved compatibility.