### PR TITLE
Fix include paths for ROS2 headers

### DIFF
--- a/fixposition_driver_ros2/include/fixposition_driver_ros2/fixposition_driver_node.hpp
+++ b/fixposition_driver_ros2/include/fixposition_driver_ros2/fixposition_driver_node.hpp
@@ -21,10 +21,10 @@
 #include <unordered_map>
 
 /* ROS2 */
-#include <nav_msgs/msg/odometry.h>
+#include <nav_msgs/msg/odometry.hpp>
 #include <rcl/rcl.h>
-#include <sensor_msgs/msg/imu.h>
-#include <sensor_msgs/msg/nav_sat_fix.h>
+#include <sensor_msgs/msg/imu.hpp>
+#include <sensor_msgs/msg/nav_sat_fix.hpp>
 #include <tf2_ros/static_transform_broadcaster.h>
 #include <tf2_ros/transform_broadcaster.h>
 #include <tf2_ros/transform_listener.h>

--- a/fixposition_driver_ros2/src/data_to_ros2.cpp
+++ b/fixposition_driver_ros2/src/data_to_ros2.cpp
@@ -13,7 +13,7 @@
  */
 
 /* ROS */
-#include <tf2_eigen/tf2_eigen.h>
+#include <tf2_eigen/tf2_eigen.hpp>
 
 /* PACKAGE */
 #include <fixposition_driver_ros2/data_to_ros2.hpp>

--- a/fixposition_driver_ros2/src/data_to_ros2.cpp
+++ b/fixposition_driver_ros2/src/data_to_ros2.cpp
@@ -13,7 +13,12 @@
  */
 
 /* ROS */
+#if __has_include(<tf2_eigen/tf2_eigen.hpp>)
 #include <tf2_eigen/tf2_eigen.hpp>
+#else
+// This header was deprecated as of ROS2 Humble, but is still required in order to support Foxy.
+#include <tf2_eigen/tf2_eigen.h>
+#endif
 
 /* PACKAGE */
 #include <fixposition_driver_ros2/data_to_ros2.hpp>


### PR DESCRIPTION
This is a minor fix. I noticed a couple of include paths for ROS2 headers are using .h instead of .hpp, so it was failing to compile for me.