### PR TITLE
Mark ROS 1 dependencies correctly in package.xml

### DIFF
--- a/fixposition_driver_lib/package.xml
+++ b/fixposition_driver_lib/package.xml
@@ -11,6 +11,7 @@
     <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
     <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
     <test_depend condition="$ROS_VERSION == 2">ament_cmake_gtest</test_depend>
+    <depend>boost</depend>
     <depend condition="$ROS_VERSION == 1">roscpp</depend>
     <depend condition="$ROS_VERSION == 1">tf</depend>
     <depend>nav_msgs</depend>

--- a/fixposition_driver_lib/package.xml
+++ b/fixposition_driver_lib/package.xml
@@ -11,14 +11,14 @@
     <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
     <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
     <test_depend condition="$ROS_VERSION == 2">ament_cmake_gtest</test_depend>
-    <depend>roscpp</depend>
-    <depend>tf</depend>
+    <depend condition="$ROS_VERSION == 1">roscpp</depend>
+    <depend condition="$ROS_VERSION == 1">tf</depend>
     <depend>nav_msgs</depend>
     <depend>sensor_msgs</depend>
     <depend>std_msgs</depend>
     <depend>geometry_msgs</depend>
-    <depend>message_generation</depend>
-    <depend>message_runtime</depend>
+    <depend condition="$ROS_VERSION == 1">message_generation</depend>
+    <depend condition="$ROS_VERSION == 1">message_runtime</depend>
     <depend>fixposition_gnss_tf</depend>
     <export>
         <build_type>cmake</build_type>

--- a/fixposition_driver_ros2/package.xml
+++ b/fixposition_driver_ros2/package.xml
@@ -9,17 +9,24 @@
     <license>MIT</license>
 
     <buildtool_depend>ament_cmake</buildtool_depend>
-    <exec_depend>rclcpp</exec_depend>
     <buildtool_depend>rosidl_default_generators</buildtool_depend>
-    <exec_depend>rosidl_default_runtime</exec_depend>
+
     <member_of_group>rosidl_interface_packages</member_of_group>
+
     <build_depend>builtin_interfaces</build_depend>
+
+    <depend>fixposition_driver_lib</depend>
+    <depend>fixposition_gnss_tf</depend>
+    <depend>geometry_msgs</depend>
     <depend>nav_msgs</depend>
     <depend>sensor_msgs</depend>
     <depend>std_msgs</depend>
-    <depend>geometry_msgs</depend>
-    <depend>fixposition_gnss_tf</depend>
-    <depend>fixposition_driver_lib</depend>
+    <depend>tf2</depend>
+    <depend>tf2_eigen</depend>
+    <depend>tf2_ros</depend>
+
+    <exec_depend>rclcpp</exec_depend>
+    <exec_depend>rosidl_default_runtime</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
When trying to do a `rosdep install` for this in ROS 2, it fails because of ROS 1 specific dependencies specified in `fixposition_driver_lib`. It builds fine otherwise, so just mark those ones with a conditional.