### PR TITLE
Feature/gpgga

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,12 @@ The output is published on the following:
     | `/fixposition/gnss1` | `sensor_msgs/NavSatFix` | as configured on web-interface | Latitude, Longitude and Height |
     | `/fixposition/gnss2` | `sensor_msgs/NavSatFix` | as configured on web-interface | Latitude, Longitude and Height |
 
+-   The Vision-RTK2 can also output an average GNSS-based LLH position (i.e., only GNSS, not Fusion) and heading estimate based on SOG and COG (i.e., the platform must be moving for it to be accurate) by utilizing several NMEA messages, which serves as an auxiliary output until Fusion is fully initialized. To do this, enable the NMEA-GP-GGA_GNSS, NMEA-GP-RMC_GNSS, and NMEA-GP-ZDA_GNSS messages. This message's output frequency equals the lowest frequency of any of these three message types. **Note: This output should only be used until Fusion is fully initialized.**
+
+    | Topic                | Message Type            | Frequency                      | Description                    |
+    | -------------------- | ----------------------- | ------------------------------ | ------------------------------ |
+    | `/fixposition/nmea` | `fixposition_driver/NMEA` | as configured on web-interface | Latitude, Longitude and Height |
+
 #### Vision-RTK2 IMU data
 
 -   From RAWIMU, at 200Hz

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ The output is published on the following:
     | `/fixposition/gnss1` | `sensor_msgs/NavSatFix` | as configured on web-interface | Latitude, Longitude and Height |
     | `/fixposition/gnss2` | `sensor_msgs/NavSatFix` | as configured on web-interface | Latitude, Longitude and Height |
 
--   The Vision-RTK2 can also output an average GNSS-based LLH position (i.e., only GNSS, not Fusion) and heading estimate based on SOG and COG (i.e., the platform must be moving for it to be accurate) by utilizing several NMEA messages, which serves as an auxiliary output until Fusion is fully initialized. To do this, enable the NMEA-GP-GGA_GNSS, NMEA-GP-RMC_GNSS, and NMEA-GP-ZDA_GNSS messages. This message's output frequency equals the lowest frequency of any of these three message types. **Note: This output should only be used until Fusion is fully initialized.**
+-   The Vision-RTK2 can also output an average GNSS-based LLH position (i.e., **only GNSS, not Fusion**) and heading estimate based on speed over ground (SOG) and course over ground (COG) - (i.e., **the platform must be moving for it to be accurate**) by utilizing several NMEA messages, which serves as an auxiliary output until Fusion is fully initialized. To do this, enable the NMEA-GP-GGA_GNSS, NMEA-GP-RMC_GNSS, and NMEA-GP-ZDA_GNSS messages. This message's output frequency equals the lowest frequency of any of these three message types. **Note: This output should only be used until Fusion is fully initialized.**
 
     | Topic                | Message Type            | Frequency                      | Description                    |
     | -------------------- | ----------------------- | ------------------------------ | ------------------------------ |

--- a/fixposition_driver_lib/CMakeLists.txt
+++ b/fixposition_driver_lib/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(
   src/parser.cpp
   src/gpgga.cpp
   src/gpzda.cpp
+  src/gprmc.cpp
 )
 
 target_link_libraries(${PROJECT_NAME} ${fixposition_gnss_tf_LIBRARIES} ${Boost_LIBRARIES} pthread)

--- a/fixposition_driver_lib/CMakeLists.txt
+++ b/fixposition_driver_lib/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(
   src/tf.cpp
   src/helper.cpp
   src/parser.cpp
+  src/gpgga.cpp
 )
 
 target_link_libraries(${PROJECT_NAME} ${fixposition_gnss_tf_LIBRARIES} ${Boost_LIBRARIES} pthread)

--- a/fixposition_driver_lib/CMakeLists.txt
+++ b/fixposition_driver_lib/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(
   src/helper.cpp
   src/parser.cpp
   src/gpgga.cpp
+  src/gpzda.cpp
 )
 
 target_link_libraries(${PROJECT_NAME} ${fixposition_gnss_tf_LIBRARIES} ${Boost_LIBRARIES} pthread)

--- a/fixposition_driver_lib/include/fixposition_driver_lib/converter/gpgga.hpp
+++ b/fixposition_driver_lib/include/fixposition_driver_lib/converter/gpgga.hpp
@@ -58,8 +58,7 @@ class GpggaConverter : public BaseAsciiConverter {
     NavSatFixData msg_;
     std::vector<GpggaObserver> obs_;
     const std::string header_ = "LLH";
-    static constexpr const int kVersion_ = 1;
-    static constexpr const int kSize_ = 14;
+    static constexpr const int kSize_ = 15;
 };
 }  // namespace fixposition
 #endif  // __FIXPOSITION_DRIVER_LIB_CONVERTER_GPGGA__

--- a/fixposition_driver_lib/include/fixposition_driver_lib/converter/gpgga.hpp
+++ b/fixposition_driver_lib/include/fixposition_driver_lib/converter/gpgga.hpp
@@ -1,0 +1,65 @@
+/**
+ *  @file
+ *  @brief Declaration of GpggaConverter
+ *
+ * \verbatim
+ *  ___    ___
+ *  \  \  /  /
+ *   \  \/  /   Fixposition AG
+ *   /  /\  \   All right reserved.
+ *  /__/  \__\
+ * \endverbatim
+ *
+ */
+
+#ifndef __FIXPOSITION_DRIVER_LIB_CONVERTER_GPGGA__
+#define __FIXPOSITION_DRIVER_LIB_CONVERTER_GPGGA__
+
+/* SYSTEM / STL */
+
+/* EXTERNAL */
+
+/* PACKAGE */
+#include <fixposition_driver_lib/converter/base_converter.hpp>
+#include <fixposition_driver_lib/msg_data.hpp>
+#include <fixposition_driver_lib/time_conversions.hpp>
+
+namespace fixposition {
+
+class GpggaConverter : public BaseAsciiConverter {
+   public:
+    using GpggaObserver = std::function<void(const NavSatFixData&)>;
+    /**
+     * @brief Construct a new GpggaConverter
+     *
+     */
+    GpggaConverter() {}
+
+    ~GpggaConverter() = default;
+
+    /**
+     * @brief Take comma-delimited tokens of GPGGA message, convert to Data structs and if available,
+     * call observers
+     * Example:
+     * $GPGGA,151229.40,4723.54108,N,00826.88485,E,4,12,00.98,473.5,M,,,,*3A\r\n
+     *
+     * @param[in] tokens message split in tokens
+     */
+    void ConvertTokens(const std::vector<std::string>& tokens) final;
+
+    /**
+     * @brief Add Observer to call at the end of ConvertTokens()
+     *
+     * @param[in] ob
+     */
+    void AddObserver(GpggaObserver ob) { obs_.push_back(ob); }
+
+   private:
+    NavSatFixData msg_;
+    std::vector<GpggaObserver> obs_;
+    const std::string header_ = "LLH";
+    static constexpr const int kVersion_ = 1;
+    static constexpr const int kSize_ = 14;
+};
+}  // namespace fixposition
+#endif  // __FIXPOSITION_DRIVER_LIB_CONVERTER_GPGGA__

--- a/fixposition_driver_lib/include/fixposition_driver_lib/converter/gprmc.hpp
+++ b/fixposition_driver_lib/include/fixposition_driver_lib/converter/gprmc.hpp
@@ -1,0 +1,64 @@
+/**
+ *  @file
+ *  @brief Declaration of GprmcConverter
+ *
+ * \verbatim
+ *  ___    ___
+ *  \  \  /  /
+ *   \  \/  /   Fixposition AG
+ *   /  /\  \   All right reserved.
+ *  /__/  \__\
+ * \endverbatim
+ *
+ */
+
+#ifndef __FIXPOSITION_DRIVER_LIB_CONVERTER_GPRMC__
+#define __FIXPOSITION_DRIVER_LIB_CONVERTER_GPRMC__
+
+/* SYSTEM / STL */
+
+/* EXTERNAL */
+
+/* PACKAGE */
+#include <fixposition_driver_lib/converter/base_converter.hpp>
+#include <fixposition_driver_lib/msg_data.hpp>
+#include <fixposition_driver_lib/time_conversions.hpp>
+
+namespace fixposition {
+
+class GprmcConverter : public BaseAsciiConverter {
+   public:
+    using GprmcObserver = std::function<void(const GprmcData&)>;
+    /**
+     * @brief Construct a new GprmcConverter
+     *
+     */
+    GprmcConverter() {}
+
+    ~GprmcConverter() = default;
+
+    /**
+     * @brief Take comma-delimited tokens of GPRMC message, convert to Data structs and if available,
+     * call observers
+     * Example:
+     * $GPRMC,151227.40,A,4723.54036,N,00826.88672,E,0.0,81.6,111022,,,R*7C\r\n
+     *
+     * @param[in] tokens message split in tokens
+     */
+    void ConvertTokens(const std::vector<std::string>& tokens) final;
+
+    /**
+     * @brief Add Observer to call at the end of ConvertTokens()
+     *
+     * @param[in] ob
+     */
+    void AddObserver(GprmcObserver ob) { obs_.push_back(ob); }
+
+   private:
+    GprmcData msg_;
+    std::vector<GprmcObserver> obs_;
+    const std::string header_ = "LLH";
+    static constexpr const int kSize_ = 13;
+};
+}  // namespace fixposition
+#endif  // __FIXPOSITION_DRIVER_LIB_CONVERTER_GPRMC__

--- a/fixposition_driver_lib/include/fixposition_driver_lib/converter/gpzda.hpp
+++ b/fixposition_driver_lib/include/fixposition_driver_lib/converter/gpzda.hpp
@@ -1,6 +1,6 @@
 /**
  *  @file
- *  @brief Declaration of GpggaConverter
+ *  @brief Declaration of GpzdaConverter
  *
  * \verbatim
  *  ___    ___
@@ -12,8 +12,8 @@
  *
  */
 
-#ifndef __FIXPOSITION_DRIVER_LIB_CONVERTER_GPGGA__
-#define __FIXPOSITION_DRIVER_LIB_CONVERTER_GPGGA__
+#ifndef __FIXPOSITION_DRIVER_LIB_CONVERTER_GPZDA__
+#define __FIXPOSITION_DRIVER_LIB_CONVERTER_GPZDA__
 
 /* SYSTEM / STL */
 
@@ -23,25 +23,26 @@
 #include <fixposition_driver_lib/converter/base_converter.hpp>
 #include <fixposition_driver_lib/msg_data.hpp>
 #include <fixposition_driver_lib/time_conversions.hpp>
+#include <chrono>
 
 namespace fixposition {
 
-class GpggaConverter : public BaseAsciiConverter {
+class GpzdaConverter : public BaseAsciiConverter {
    public:
-    using GpggaObserver = std::function<void(const GpggaData&)>;
+    using GpzdaObserver = std::function<void(const GpzdaData&)>;
     /**
-     * @brief Construct a new GpggaConverter
+     * @brief Construct a new GpzdaConverter
      *
      */
-    GpggaConverter() {}
+    GpzdaConverter() {}
 
-    ~GpggaConverter() = default;
+    ~GpzdaConverter() = default;
 
     /**
-     * @brief Take comma-delimited tokens of GPGGA message, convert to Data structs and if available,
+     * @brief Take comma-delimited tokens of GPZDA message, convert to Data structs and if available,
      * call observers
      * Example:
-     * $GPGGA,151229.40,4723.54108,N,00826.88485,E,4,12,00.98,473.5,M,,,,*3A\r\n
+     * $GPZDA,090411.0001,10,10,2023,00,00*69\r\n
      *
      * @param[in] tokens message split in tokens
      */
@@ -52,13 +53,13 @@ class GpggaConverter : public BaseAsciiConverter {
      *
      * @param[in] ob
      */
-    void AddObserver(GpggaObserver ob) { obs_.push_back(ob); }
+    void AddObserver(GpzdaObserver ob) { obs_.push_back(ob); }
 
    private:
-    GpggaData msg_;
-    std::vector<GpggaObserver> obs_;
+    GpzdaData msg_;
+    std::vector<GpzdaObserver> obs_;
     const std::string header_ = "LLH";
-    static constexpr const int kSize_ = 15;
+    static constexpr const int kSize_ = 7;
 };
 }  // namespace fixposition
-#endif  // __FIXPOSITION_DRIVER_LIB_CONVERTER_GPGGA__
+#endif  // __FIXPOSITION_DRIVER_LIB_CONVERTER_GPZDA__

--- a/fixposition_driver_lib/include/fixposition_driver_lib/msg_data.hpp
+++ b/fixposition_driver_lib/include/fixposition_driver_lib/msg_data.hpp
@@ -132,5 +132,24 @@ struct NavSatFixData {
     NavSatFixData() : latitude(0.0), longitude(0.0), altitude(0.0), position_covariance_type(0) { cov.setZero(); }
 };
 
+struct GpggaData {
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    std::string time;
+    double latitude;
+    double longitude;
+    double altitude;
+    Eigen::Matrix<double, 3, 3> cov;
+    int position_covariance_type;
+    GpggaData() : latitude(0.0), longitude(0.0), altitude(0.0), position_covariance_type(0) { cov.setZero(); }
+};
+
+struct GpzdaData {
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    std::string time;
+    std::string date;
+    times::GpsTime stamp;
+    GpzdaData() : time(""), date("") {}
+};
+
 }  // namespace fixposition
 #endif  //__FIXPOSITION_DRIVER_LIB_MSG_DATA__

--- a/fixposition_driver_lib/include/fixposition_driver_lib/msg_data.hpp
+++ b/fixposition_driver_lib/include/fixposition_driver_lib/msg_data.hpp
@@ -151,5 +151,16 @@ struct GpzdaData {
     GpzdaData() : time(""), date("") {}
 };
 
+struct GprmcData {
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    std::string time;
+    std::string mode;
+    double latitude;
+    double longitude;
+    double speed;
+    double course;
+    GprmcData() : latitude(0.0), longitude(0.0), speed(0.0), course(0.0) {}
+};
+
 }  // namespace fixposition
 #endif  //__FIXPOSITION_DRIVER_LIB_MSG_DATA__

--- a/fixposition_driver_lib/src/fixposition_driver.cpp
+++ b/fixposition_driver_lib/src/fixposition_driver.cpp
@@ -23,6 +23,7 @@
 #include <fixposition_driver_lib/converter/odometry.hpp>
 #include <fixposition_driver_lib/converter/tf.hpp>
 #include <fixposition_driver_lib/converter/gpgga.hpp>
+#include <fixposition_driver_lib/converter/gpzda.hpp>
 #include <fixposition_driver_lib/fixposition_driver.hpp>
 #include <fixposition_driver_lib/helper.hpp>
 #include <fixposition_driver_lib/parser.hpp>
@@ -140,6 +141,8 @@ bool FixpositionDriver::InitializeConverters() {
             a_converters_["CORRIMU"] = std::unique_ptr<ImuConverter>(new ImuConverter(true));
         } else if (format == "GPGGA") {
             a_converters_["GPGGA"] = std::unique_ptr<GpggaConverter>(new GpggaConverter());
+        } else if (format == "GPZDA") {
+            a_converters_["GPZDA"] = std::unique_ptr<GpzdaConverter>(new GpzdaConverter());
         } else if (format == "TF") {
             if (a_converters_.find("TF") == a_converters_.end()) {
                 a_converters_["TF"] = std::unique_ptr<TfConverter>(new TfConverter());
@@ -233,7 +236,7 @@ void FixpositionDriver::NmeaConvertAndPublish(const std::string& msg) {
     SplitMessage(tokens, msg.substr(1, star_pos - 1), ",");
 
     // if it doesn't start with FP then do nothing
-    if ((tokens.at(0) != "FP") && (tokens.at(0) != "GPGGA")) {
+    if ((tokens.at(0) != "FP") && (tokens.at(0) != "GPGGA") && (tokens.at(0) != "GPZDA")) {
         return;
     }
 
@@ -241,6 +244,8 @@ void FixpositionDriver::NmeaConvertAndPublish(const std::string& msg) {
     std::string _header;
     if (tokens.at(0) == "GPGGA") {
         _header = "GPGGA";
+    } else if (tokens.at(0) == "GPZDA") {
+        _header = "GPZDA";
     } else {
         _header = tokens.at(1);
     }

--- a/fixposition_driver_lib/src/fixposition_driver.cpp
+++ b/fixposition_driver_lib/src/fixposition_driver.cpp
@@ -233,7 +233,7 @@ void FixpositionDriver::NmeaConvertAndPublish(const std::string& msg) {
     SplitMessage(tokens, msg.substr(1, star_pos - 1), ",");
 
     // if it doesn't start with FP then do nothing
-    if ((tokens.at(0) != "FP") || (tokens.at(0) != "GPGGA")) {
+    if ((tokens.at(0) != "FP") && (tokens.at(0) != "GPGGA")) {
         return;
     }
 
@@ -245,8 +245,6 @@ void FixpositionDriver::NmeaConvertAndPublish(const std::string& msg) {
         _header = tokens.at(1);
     }
     const std::string header = _header;
-    std::cout << "Header: " << _header << std::endl;
-    std::cout << "Header: " << header << std::endl;
 
     // If we have a converter available, convert to ros. Currently supported are "FP", "LLH", "TF", "RAWIMU", "CORRIMU"
     if (a_converters_[header] != nullptr) {

--- a/fixposition_driver_lib/src/fixposition_driver.cpp
+++ b/fixposition_driver_lib/src/fixposition_driver.cpp
@@ -24,6 +24,7 @@
 #include <fixposition_driver_lib/converter/tf.hpp>
 #include <fixposition_driver_lib/converter/gpgga.hpp>
 #include <fixposition_driver_lib/converter/gpzda.hpp>
+#include <fixposition_driver_lib/converter/gprmc.hpp>
 #include <fixposition_driver_lib/fixposition_driver.hpp>
 #include <fixposition_driver_lib/helper.hpp>
 #include <fixposition_driver_lib/parser.hpp>
@@ -143,6 +144,8 @@ bool FixpositionDriver::InitializeConverters() {
             a_converters_["GPGGA"] = std::unique_ptr<GpggaConverter>(new GpggaConverter());
         } else if (format == "GPZDA") {
             a_converters_["GPZDA"] = std::unique_ptr<GpzdaConverter>(new GpzdaConverter());
+        } else if (format == "GPRMC") {
+            a_converters_["GPRMC"] = std::unique_ptr<GprmcConverter>(new GprmcConverter());
         } else if (format == "TF") {
             if (a_converters_.find("TF") == a_converters_.end()) {
                 a_converters_["TF"] = std::unique_ptr<TfConverter>(new TfConverter());
@@ -236,7 +239,7 @@ void FixpositionDriver::NmeaConvertAndPublish(const std::string& msg) {
     SplitMessage(tokens, msg.substr(1, star_pos - 1), ",");
 
     // if it doesn't start with FP then do nothing
-    if ((tokens.at(0) != "FP") && (tokens.at(0) != "GPGGA") && (tokens.at(0) != "GPZDA")) {
+    if ((tokens.at(0) != "FP") && (tokens.at(0) != "GPGGA") && (tokens.at(0) != "GPZDA") && (tokens.at(0) != "GPRMC")) {
         return;
     }
 
@@ -246,6 +249,8 @@ void FixpositionDriver::NmeaConvertAndPublish(const std::string& msg) {
         _header = "GPGGA";
     } else if (tokens.at(0) == "GPZDA") {
         _header = "GPZDA";
+    } else if (tokens.at(0) == "GPRMC") {
+        _header = "GPRMC";
     } else {
         _header = tokens.at(1);
     }

--- a/fixposition_driver_lib/src/gpgga.cpp
+++ b/fixposition_driver_lib/src/gpgga.cpp
@@ -41,13 +41,12 @@ void GpggaConverter::ConvertTokens(const std::vector<std::string>& tokens) {
     bool ok = tokens.size() == kSize_;
     if (!ok) {
         std::cout << "Error in parsing GPGGA string with " << tokens.size() << " fields! GPGGA message will be empty.\n";
-        msg_ = NavSatFixData();
+        msg_ = GpggaData();
         return;
     }
 
     // Header stamps
-    msg_.stamp = times::GpsTime(0, 0); // ConvertGpsTime(tokens.at(time_idx), tokens.at(time_idx));
-    msg_.frame_id = "LLH";
+    msg_.time = tokens.at(time_idx);
 
     // LLH coordinates
     const std::string _latstr = tokens.at(lat_idx);

--- a/fixposition_driver_lib/src/gpgga.cpp
+++ b/fixposition_driver_lib/src/gpgga.cpp
@@ -46,12 +46,20 @@ void GpggaConverter::ConvertTokens(const std::vector<std::string>& tokens) {
     }
 
     // Header stamps
-    msg_.stamp = ConvertGpsTime(tokens.at(time_idx), tokens.at(time_idx));
+    msg_.stamp = times::GpsTime(0, 0); // ConvertGpsTime(tokens.at(time_idx), tokens.at(time_idx));
     msg_.frame_id = "LLH";
 
     // LLH coordinates
-    msg_.latitude = StringToDouble(tokens.at(lat_idx));
-    msg_.longitude = StringToDouble(tokens.at(lon_idx));
+    const std::string _latstr = tokens.at(lat_idx);
+    double _lat = StringToDouble(_latstr.substr(0,2)) + StringToDouble((_latstr.substr(2))) / 60;
+    if (tokens.at(lat_ns_idx).compare("S") == 0) _lat *= -1;
+    msg_.latitude = _lat;
+
+    const std::string _lonstr = tokens.at(lon_idx);
+    double _lon = StringToDouble(_lonstr.substr(0,3)) + StringToDouble((_lonstr.substr(3))) / 60;
+    if (tokens.at(lon_ew_idx).compare("W") == 0) _lon *= -1;
+    msg_.longitude = _lon;
+
     msg_.altitude = StringToDouble(tokens.at(alt_idx));
 
     // Covariance diagonals

--- a/fixposition_driver_lib/src/gpgga.cpp
+++ b/fixposition_driver_lib/src/gpgga.cpp
@@ -1,0 +1,75 @@
+/**
+ *  @file
+ *  @brief Implementation of GpggaConverter converter
+ *
+ * \verbatim
+ *  ___    ___
+ *  \  \  /  /
+ *   \  \/  /   Fixposition AG
+ *   /  /\  \   All right reserved.
+ *  /__/  \__\
+ * \endverbatim
+ *
+ */
+
+/* SYSTEM / STL */
+#include <iostream>
+
+/* PACKAGE */
+#include <fixposition_driver_lib/converter/gpgga.hpp>
+
+namespace fixposition {
+
+/// msg field indices
+static constexpr const int time_idx = 1;
+static constexpr const int lat_idx = 2;
+static constexpr const int lat_ns_idx = 3;
+static constexpr const int lon_idx = 4;
+static constexpr const int lon_ew_idx = 5;
+static constexpr const int quality_idx = 6;
+static constexpr const int num_sv_idx = 7;
+static constexpr const int hdop_idx = 8;
+static constexpr const int alt_idx = 9;
+static constexpr const int alt_unit_idx = 10;
+static constexpr const int sep_idx = 11;
+static constexpr const int sep_unit_idx = 12;
+static constexpr const int diff_age_idx = 13;
+static constexpr const int diff_sta_idx = 14;
+
+void GpggaConverter::ConvertTokens(const std::vector<std::string>& tokens) {
+    // Check if message size is wrong
+    bool ok = tokens.size() == kSize_;
+    if (!ok) {
+        std::cout << "Error in parsing GPGGA string with " << tokens.size() << " fields! GPGGA message will be empty.\n";
+        msg_ = NavSatFixData();
+        return;
+    }
+
+    // Header stamps
+    msg_.stamp = ConvertGpsTime(tokens.at(time_idx), tokens.at(time_idx));
+    msg_.frame_id = "LLH";
+
+    // LLH coordinates
+    msg_.latitude = StringToDouble(tokens.at(lat_idx));
+    msg_.longitude = StringToDouble(tokens.at(lon_idx));
+    msg_.altitude = StringToDouble(tokens.at(alt_idx));
+
+    // Covariance diagonals
+    const double hdop = StringToDouble(tokens.at(hdop_idx));
+    msg_.cov(0, 0) = hdop * hdop;
+    msg_.cov(1, 1) = hdop * hdop;
+    msg_.cov(2, 2) = 4 * hdop * hdop;
+
+    // Rest of covariance fields
+    msg_.cov(0, 1) = msg_.cov(1, 0) = 0.0;
+    msg_.cov(0, 2) = msg_.cov(2, 0) = 0.0;
+    msg_.cov(1, 2) = msg_.cov(2, 1) = 0.0;
+    msg_.position_covariance_type = 1; // COVARIANCE_TYPE_APPROXIMATED
+
+    // Process all observers
+    for (auto& ob : obs_) {
+        ob(msg_);
+    }
+}
+
+}  // namespace fixposition

--- a/fixposition_driver_lib/src/gprmc.cpp
+++ b/fixposition_driver_lib/src/gprmc.cpp
@@ -1,0 +1,73 @@
+/**
+ *  @file
+ *  @brief Implementation of GprmcConverter converter
+ *
+ * \verbatim
+ *  ___    ___
+ *  \  \  /  /
+ *   \  \/  /   Fixposition AG
+ *   /  /\  \   All right reserved.
+ *  /__/  \__\
+ * \endverbatim
+ *
+ */
+
+/* SYSTEM / STL */
+#include <iostream>
+
+/* PACKAGE */
+#include <fixposition_driver_lib/converter/gprmc.hpp>
+
+namespace fixposition {
+
+/// msg field indices
+static constexpr const int time_idx = 1;
+static constexpr const int status_idx = 2;
+static constexpr const int lat_idx = 3;
+static constexpr const int lat_ns_idx = 4;
+static constexpr const int lon_idx = 5;
+static constexpr const int lon_ew_idx = 6;
+static constexpr const int speed_idx = 7;
+static constexpr const int course_idx = 8;
+static constexpr const int date_idx = 9;
+static constexpr const int magvar_idx = 10;
+static constexpr const int magvar_ew = 11;
+static constexpr const int mode_idx = 12;
+
+void GprmcConverter::ConvertTokens(const std::vector<std::string>& tokens) {
+    // Check if message size is wrong
+    bool ok = tokens.size() == kSize_;
+    if (!ok) {
+        std::cout << "Error in parsing GPRMC string with " << tokens.size() << " fields! GPRMC message will be empty.\n";
+        msg_ = GprmcData();
+        return;
+    }
+
+    // Header stamps
+    msg_.time = tokens.at(time_idx);
+
+    // LLH coordinates
+    const std::string _latstr = tokens.at(lat_idx);
+    double _lat = StringToDouble(_latstr.substr(0,2)) + StringToDouble((_latstr.substr(2))) / 60;
+    if (tokens.at(lat_ns_idx).compare("S") == 0) _lat *= -1;
+    msg_.latitude = _lat;
+
+    const std::string _lonstr = tokens.at(lon_idx);
+    double _lon = StringToDouble(_lonstr.substr(0,3)) + StringToDouble((_lonstr.substr(3))) / 60;
+    if (tokens.at(lon_ew_idx).compare("W") == 0) _lon *= -1;
+    msg_.longitude = _lon;
+
+    // Speed and course over groung
+    msg_.speed = StringToDouble(tokens.at(speed_idx)) * 1852.0 / 3600.0;
+    msg_.course = StringToDouble(tokens.at(course_idx));
+
+    // Get GPS status
+    msg_.mode = tokens.at(mode_idx);
+
+    // Process all observers
+    for (auto& ob : obs_) {
+        ob(msg_);
+    }
+}
+
+}  // namespace fixposition

--- a/fixposition_driver_lib/src/gprmc.cpp
+++ b/fixposition_driver_lib/src/gprmc.cpp
@@ -20,6 +20,9 @@
 
 namespace fixposition {
 
+// unit transformation constant
+static constexpr double knots_to_ms = 1852.0 / 3600.0; //!< convert knots to m/s
+
 /// msg field indices
 static constexpr const int time_idx = 1;
 static constexpr const int status_idx = 2;
@@ -57,8 +60,8 @@ void GprmcConverter::ConvertTokens(const std::vector<std::string>& tokens) {
     if (tokens.at(lon_ew_idx).compare("W") == 0) _lon *= -1;
     msg_.longitude = _lon;
 
-    // Speed and course over groung
-    msg_.speed = StringToDouble(tokens.at(speed_idx)) * 1852.0 / 3600.0;
+    // Speed [m/s] and course [deg] over ground
+    msg_.speed = StringToDouble(tokens.at(speed_idx)) * knots_to_ms;
     msg_.course = StringToDouble(tokens.at(course_idx));
 
     // Get GPS status

--- a/fixposition_driver_lib/src/gprmc.cpp
+++ b/fixposition_driver_lib/src/gprmc.cpp
@@ -20,7 +20,7 @@
 
 namespace fixposition {
 
-// unit transformation constant
+// unit conversion constant
 static constexpr double knots_to_ms = 1852.0 / 3600.0; //!< convert knots to m/s
 
 /// msg field indices

--- a/fixposition_driver_lib/src/gpzda.cpp
+++ b/fixposition_driver_lib/src/gpzda.cpp
@@ -1,0 +1,108 @@
+/**
+ *  @file
+ *  @brief Implementation of GpzdaConverter converter
+ *
+ * \verbatim
+ *  ___    ___
+ *  \  \  /  /
+ *   \  \/  /   Fixposition AG
+ *   /  /\  \   All right reserved.
+ *  /__/  \__\
+ * \endverbatim
+ *
+ */
+
+/* SYSTEM / STL */
+#include <iostream>
+
+/* PACKAGE */
+#include <fixposition_driver_lib/converter/gpzda.hpp>
+
+namespace fixposition {
+
+/// msg field indices
+static constexpr const int time_idx = 1;
+static constexpr const int day_idx = 2;
+static constexpr const int month_idx = 3;
+static constexpr const int year_idx = 4;
+static constexpr const int local_hr_idx = 5;
+static constexpr const int local_min_idx = 6;
+
+#include <iostream>
+#include <ctime>
+#include <iomanip>
+
+// Function to convert UTC time with milliseconds to GPS time
+void convertToGPSTime(const std::string& utcTimeString, std::string& gpsWeek, std::string& gpsTimeOfWeek) {
+    // Define constants
+    const double secondsInWeek = 604800.0; // 7 days in seconds
+
+    // Parse the input string
+    std::tm tmTime = {};
+    std::istringstream iss(utcTimeString);
+    iss >> std::get_time(&tmTime, "%d/%m/%Y %H:%M:%S");
+
+    // Read milliseconds from input
+    char dot;
+    std::string milliseconds;
+    iss >> dot >> milliseconds;
+    double ms = std::stod("0." + milliseconds);
+    
+    if (iss.fail()) {
+        std::cerr << "Error parsing input string.\n";
+        return;
+    }
+    
+    // Convert UTC time to time since epoch
+    std::time_t utcTime = std::mktime(&tmTime);
+
+    // GPS epoch time (January 6, 1980)
+    std::tm gpsEpoch = {};
+    gpsEpoch.tm_year = 80; // years since 1900
+    gpsEpoch.tm_mon = 0;   // months since January
+    gpsEpoch.tm_mday = 6;  // day of the month
+    std::time_t gpsEpochTime = std::mktime(&gpsEpoch);
+
+    // Calculate GPS time of week and GPS week number
+    double timeDifference = std::difftime(utcTime, gpsEpochTime);
+    int gpsWeekNumber = static_cast<int>(std::floor(timeDifference / secondsInWeek));
+    double gpsTime = std::fmod(timeDifference, secondsInWeek);
+
+    // Add milliseconds to GPS time
+    gpsTime += (18 + ms);
+
+    // Convert results to strings
+    std::ostringstream ossWeek, ossTime;
+    ossWeek << gpsWeekNumber;
+    ossTime << std::fixed << std::setprecision(6) << gpsTime;
+
+    gpsWeek = ossWeek.str();
+    gpsTimeOfWeek = ossTime.str();
+}
+
+void GpzdaConverter::ConvertTokens(const std::vector<std::string>& tokens) {
+    // Check if message size is wrong
+    bool ok = tokens.size() == kSize_;
+    if (!ok) {
+        std::cout << "Error in parsing GPZDA string with " << tokens.size() << " fields! GPZDA message will be empty.\n";
+        msg_ = GpzdaData();
+        return;
+    }
+
+    // Populate time fields
+    msg_.time = tokens.at(time_idx);
+    msg_.date = tokens.at(day_idx) + '/' + tokens.at(month_idx) + '/' + tokens.at(year_idx);
+
+    // Generate GPS timestamp
+    std::string utcTimeString = msg_.date + " " + msg_.time.substr(0,2) + ":" + msg_.time.substr(2,2) + ":" + msg_.time.substr(4);
+    std::string gps_tow, gps_week;
+    convertToGPSTime(utcTimeString, gps_week, gps_tow);
+    msg_.stamp = ConvertGpsTime(gps_week, gps_tow);
+
+    // Process all observers
+    for (auto& ob : obs_) {
+        ob(msg_);
+    }
+}
+
+}  // namespace fixposition

--- a/fixposition_driver_ros1/CMakeLists.txt
+++ b/fixposition_driver_ros1/CMakeLists.txt
@@ -26,6 +26,7 @@ add_message_files(
   FILES
   VRTK.msg
   Speed.msg
+  NMEA.msg
 )
 
 generate_messages(

--- a/fixposition_driver_ros1/include/fixposition_driver_ros1/data_to_ros1.hpp
+++ b/fixposition_driver_ros1/include/fixposition_driver_ros1/data_to_ros1.hpp
@@ -27,6 +27,7 @@
 
 /* PACKAGE */
 #include <fixposition_driver_ros1/VRTK.h>
+#include <fixposition_driver_ros1/NMEA.h>
 
 namespace fixposition {
 /**

--- a/fixposition_driver_ros1/include/fixposition_driver_ros1/fixposition_driver_node.hpp
+++ b/fixposition_driver_ros1/include/fixposition_driver_ros1/fixposition_driver_node.hpp
@@ -57,6 +57,9 @@ class FixpositionDriverNode : public FixpositionDriver {
         GpzdaData gpzda;
         GprmcData gprmc;
         
+        /**
+         * @brief Construct a new Fixposition Driver Node object
+         */
         bool checkEpoch() {
             if ((gpgga.time.compare(gpzda.time) == 0) && (gpgga.time.compare(gprmc.time) == 0)) {
                 return true;
@@ -75,6 +78,11 @@ class FixpositionDriverNode : public FixpositionDriver {
      */
     void BestGnssPosToPublishNavSatFix(const Oem7MessageHeaderMem* header, const BESTGNSSPOSMem* payload);
 
+    /**
+     * @brief Observer Function to publish NMEA message from GPGGA, GPRMC, and GPZDA once the GNSS epoch transmission is complete
+     *
+     * @param[in] data
+     */
     void PublishNmea(NmeaMessage data);
 
     ros::NodeHandle nh_;

--- a/fixposition_driver_ros1/include/fixposition_driver_ros1/fixposition_driver_node.hpp
+++ b/fixposition_driver_ros1/include/fixposition_driver_ros1/fixposition_driver_node.hpp
@@ -52,6 +52,20 @@ class FixpositionDriverNode : public FixpositionDriver {
 
     void WsCallback(const fixposition_driver_ros1::SpeedConstPtr& msg);
 
+    struct NmeaMessage {
+        GpggaData gpgga;
+        GpzdaData gpzda;
+        NavSatFixData msg;
+        
+        bool checkEpoch() {
+            if (gpgga.time.compare(gpzda.time) == 0) {
+                return true;
+            } else {
+                return false;
+            }
+        }  
+    };
+
    private:
     /**
      * @brief Observer Functions to publish NavSatFix from BestGnssPos
@@ -61,6 +75,8 @@ class FixpositionDriverNode : public FixpositionDriver {
      */
     void BestGnssPosToPublishNavSatFix(const Oem7MessageHeaderMem* header, const BESTGNSSPOSMem* payload);
 
+    void PublishNmea(NmeaMessage data);
+
     ros::NodeHandle nh_;
     ros::Subscriber ws_sub_;  //!< wheelspeed message subscriber
 
@@ -69,13 +85,15 @@ class FixpositionDriverNode : public FixpositionDriver {
     ros::Publisher navsatfix_pub_;
     ros::Publisher navsatfix_gnss1_pub_;
     ros::Publisher navsatfix_gnss2_pub_;
-    ros::Publisher navsatfix_gpgga_pub_;
+    ros::Publisher nmea_pub_;
     ros::Publisher odometry_pub_;       //!< ECEF Odometry
     ros::Publisher poiimu_pub_;         //!< Bias corrected IMU
     ros::Publisher vrtk_pub_;           //!< VRTK message
     ros::Publisher odometry_enu0_pub_;  //!< ENU0 Odometry
     ros::Publisher eul_pub_;            //!< Euler angles Yaw-Pitch-Roll in local ENU
     ros::Publisher eul_imu_pub_;        //!< Euler angles Pitch-Roll as estimated from the IMU in local horizontal
+
+    NmeaMessage nmea_message_;
 
     tf2_ros::TransformBroadcaster br_;
     tf2_ros::StaticTransformBroadcaster static_br_;

--- a/fixposition_driver_ros1/include/fixposition_driver_ros1/fixposition_driver_node.hpp
+++ b/fixposition_driver_ros1/include/fixposition_driver_ros1/fixposition_driver_node.hpp
@@ -69,6 +69,7 @@ class FixpositionDriverNode : public FixpositionDriver {
     ros::Publisher navsatfix_pub_;
     ros::Publisher navsatfix_gnss1_pub_;
     ros::Publisher navsatfix_gnss2_pub_;
+    ros::Publisher navsatfix_gpgga_pub_;
     ros::Publisher odometry_pub_;       //!< ECEF Odometry
     ros::Publisher poiimu_pub_;         //!< Bias corrected IMU
     ros::Publisher vrtk_pub_;           //!< VRTK message

--- a/fixposition_driver_ros1/include/fixposition_driver_ros1/fixposition_driver_node.hpp
+++ b/fixposition_driver_ros1/include/fixposition_driver_ros1/fixposition_driver_node.hpp
@@ -55,10 +55,10 @@ class FixpositionDriverNode : public FixpositionDriver {
     struct NmeaMessage {
         GpggaData gpgga;
         GpzdaData gpzda;
-        NavSatFixData msg;
+        GprmcData gprmc;
         
         bool checkEpoch() {
-            if (gpgga.time.compare(gpzda.time) == 0) {
+            if ((gpgga.time.compare(gpzda.time) == 0) && (gpgga.time.compare(gprmc.time) == 0)) {
                 return true;
             } else {
                 return false;

--- a/fixposition_driver_ros1/launch/tcp.yaml
+++ b/fixposition_driver_ros1/launch/tcp.yaml
@@ -1,5 +1,5 @@
 fp_output:
-    formats: ["ODOMETRY", "LLH", "RAWIMU", "CORRIMU", "GPGGA", "TF"]
+    formats: ["ODOMETRY", "LLH", "RAWIMU", "CORRIMU", "GPGGA", "GPZDA", "TF"]
     type: tcp
     port: "21000"
     ip: "10.0.2.1" # change to VRTK2's IP address in the network

--- a/fixposition_driver_ros1/launch/tcp.yaml
+++ b/fixposition_driver_ros1/launch/tcp.yaml
@@ -2,7 +2,7 @@ fp_output:
     formats: ["ODOMETRY", "LLH", "RAWIMU", "CORRIMU", "GPGGA", "GPZDA", "GPRMC", "TF"]
     type: tcp
     port: "21000"
-    ip: "10.0.2.1" # change to VRTK2's IP address in the network
+    ip: "127.0.0.1" # change to VRTK2's IP address in the network
     rate: 200
     reconnect_delay: 5.0 # wait time in [s] until retry connection
 

--- a/fixposition_driver_ros1/launch/tcp.yaml
+++ b/fixposition_driver_ros1/launch/tcp.yaml
@@ -1,5 +1,5 @@
 fp_output:
-    formats: ["ODOMETRY", "LLH", "RAWIMU", "CORRIMU", "TF"]
+    formats: ["ODOMETRY", "LLH", "RAWIMU", "CORRIMU", "GPGGA", "TF"]
     type: tcp
     port: "21000"
     ip: "10.0.2.1" # change to VRTK2's IP address in the network

--- a/fixposition_driver_ros1/launch/tcp.yaml
+++ b/fixposition_driver_ros1/launch/tcp.yaml
@@ -1,5 +1,5 @@
 fp_output:
-    formats: ["ODOMETRY", "LLH", "RAWIMU", "CORRIMU", "GPGGA", "GPZDA", "TF"]
+    formats: ["ODOMETRY", "LLH", "RAWIMU", "CORRIMU", "GPGGA", "GPZDA", "GPRMC", "TF"]
     type: tcp
     port: "21000"
     ip: "10.0.2.1" # change to VRTK2's IP address in the network

--- a/fixposition_driver_ros1/launch/tcp.yaml
+++ b/fixposition_driver_ros1/launch/tcp.yaml
@@ -2,7 +2,7 @@ fp_output:
     formats: ["ODOMETRY", "LLH", "RAWIMU", "CORRIMU", "GPGGA", "GPZDA", "GPRMC", "TF"]
     type: tcp
     port: "21000"
-    ip: "127.0.0.1" # change to VRTK2's IP address in the network
+    ip: "10.0.2.1" # change to VRTK2's IP address in the network
     rate: 200
     reconnect_delay: 5.0 # wait time in [s] until retry connection
 

--- a/fixposition_driver_ros1/msg/NMEA.msg
+++ b/fixposition_driver_ros1/msg/NMEA.msg
@@ -1,0 +1,66 @@
+####################################################################################################
+#
+#    Copyright (c) 2023  ___     ___
+#                       \\  \\  /  /
+#                        \\  \\/  /
+#                         /  /\\  \\
+#                        /__/  \\__\\  Fixposition AG
+#
+####################################################################################################
+#
+# Fixposition NMEA Message
+#
+#
+####################################################################################################
+
+# Navigation Satellite fix for any Global Navigation Satellite System
+#
+# Specified using the WGS 84 reference ellipsoid
+
+# header.stamp specifies the ROS time for this measurement (the
+#        corresponding satellite time may be reported using the
+#        sensor_msgs/TimeReference message).
+#
+# header.frame_id is the frame of reference reported by the satellite
+#        receiver, usually the location of the antenna.  This is a
+#        Euclidean frame relative to the vehicle, not a reference
+#        ellipsoid.
+Header header
+
+# Latitude [degrees]. Positive is north of equator; negative is south.
+float64 latitude
+
+# Longitude [degrees]. Positive is east of prime meridian; negative is west.
+float64 longitude
+
+# Altitude [m]. Positive is above the WGS 84 ellipsoid.
+float64 altitude
+
+# Speed over ground [m/s]
+float64 speed
+
+# Course over ground [deg]
+float64 course
+
+# Position covariance [m^2] defined relative to a tangential plane
+# through the reported position. The components are East, North, and
+# Up (ENU), in row-major order.
+#
+# Beware: this coordinate system exhibits singularities at the poles.
+
+float64[9] position_covariance
+
+# If the covariance of the fix is known, fill it in completely. If the
+# GPS receiver provides the variance of each measurement, put them
+# along the diagonal. If only Dilution of Precision is available,
+# estimate an approximate covariance from that.
+
+uint8 COVARIANCE_TYPE_UNKNOWN = 0
+uint8 COVARIANCE_TYPE_APPROXIMATED = 1
+uint8 COVARIANCE_TYPE_DIAGONAL_KNOWN = 2
+uint8 COVARIANCE_TYPE_KNOWN = 3
+
+uint8 position_covariance_type
+
+# Positioning system mode indicator, R (RTK fixed), F (RTK float), A (no RTK), E, N
+string mode

--- a/fixposition_driver_ros1/src/fixposition_driver_node.cpp
+++ b/fixposition_driver_ros1/src/fixposition_driver_node.cpp
@@ -24,6 +24,7 @@
 #include <fixposition_driver_lib/converter/tf.hpp>
 #include <fixposition_driver_lib/converter/gpgga.hpp>
 #include <fixposition_driver_lib/converter/gpzda.hpp>
+#include <fixposition_driver_lib/converter/gprmc.hpp>
 #include <fixposition_driver_lib/fixposition_driver.hpp>
 #include <fixposition_driver_lib/helper.hpp>
 #include <fixposition_gnss_tf/gnss_tf.hpp>
@@ -43,7 +44,7 @@ FixpositionDriverNode::FixpositionDriverNode(const FixpositionDriverParams& para
       navsatfix_pub_(nh_.advertise<sensor_msgs::NavSatFix>("/fixposition/navsatfix", 100)),
       navsatfix_gnss1_pub_(nh_.advertise<sensor_msgs::NavSatFix>("/fixposition/gnss1", 100)),
       navsatfix_gnss2_pub_(nh_.advertise<sensor_msgs::NavSatFix>("/fixposition/gnss2", 100)),
-      nmea_pub_(nh_.advertise<sensor_msgs::NavSatFix>("/fixposition/nmea", 100)),
+      nmea_pub_(nh_.advertise<fixposition_driver_ros1::NMEA>("/fixposition/nmea", 100)),
       //   ODOMETRY
       odometry_pub_(nh_.advertise<nav_msgs::Odometry>("/fixposition/odometry", 100)),
       poiimu_pub_(nh_.advertise<sensor_msgs::Imu>("/fixposition/poiimu", 100)),
@@ -177,6 +178,14 @@ void FixpositionDriverNode::RegisterObservers() {
                     PublishNmea(nmea_message_);
                 }
             });
+        } else if (format == "GPRMC") {
+            dynamic_cast<GprmcConverter*>(a_converters_["GPRMC"].get())->AddObserver([this](const GprmcData& data) {
+                // GPRMC Observer Lambda
+                if (nmea_pub_.getNumSubscribers() > 0) {
+                    nmea_message_.gprmc = data;
+                    PublishNmea(nmea_message_);
+                }
+            });
         }
     }
 }
@@ -184,18 +193,39 @@ void FixpositionDriverNode::RegisterObservers() {
 void FixpositionDriverNode::PublishNmea(NmeaMessage data) {
     // If epoch message is complete, generate NMEA output
     if (data.checkEpoch()) {
-        sensor_msgs::NavSatFix msg;
+        // Generate new message
+        fixposition_driver_ros1::NMEA msg;
+        
+        // ROS Header
         msg.header.stamp = ros::Time::fromBoost(GpsTimeToPtime(data.gpzda.stamp));
         msg.header.frame_id = "LLH";
+        
+        // Latitude [degrees]. Positive is north of equator; negative is south
         msg.latitude = data.gpgga.latitude;
+        
+        // Longitude [degrees]. Positive is east of prime meridian; negative is west
         msg.longitude = data.gpgga.longitude;
+        
+        // Altitude [m]. Positive is above the WGS 84 ellipsoid
         msg.altitude = data.gpgga.altitude;
 
+        // Speed over ground [m/s]
+        msg.speed = data.gprmc.speed;
+        
+        // Course over ground [deg]
+        msg.course = data.gprmc.course;
+
+        // TODO: Get better position covariance from NMEA-GP-GST
+        // Position covariance [m^2]
         Eigen::Map<Eigen::Matrix<double, 3, 3>> cov_map =
             Eigen::Map<Eigen::Matrix<double, 3, 3>>(msg.position_covariance.data());
         cov_map = data.gpgga.cov;
-
         msg.position_covariance_type = data.gpgga.position_covariance_type;
+
+        // Positioning system mode indicator, R (RTK fixed), F (RTK float), A (no RTK), E, N
+        msg.mode = data.gprmc.mode;
+        
+        // Publish message
         nmea_pub_.publish(msg);
     }
 }

--- a/fixposition_driver_ros1/src/fixposition_driver_node.cpp
+++ b/fixposition_driver_ros1/src/fixposition_driver_node.cpp
@@ -22,6 +22,7 @@
 #include <fixposition_driver_lib/converter/llh.hpp>
 #include <fixposition_driver_lib/converter/odometry.hpp>
 #include <fixposition_driver_lib/converter/tf.hpp>
+#include <fixposition_driver_lib/converter/gpgga.hpp>
 #include <fixposition_driver_lib/fixposition_driver.hpp>
 #include <fixposition_driver_lib/helper.hpp>
 #include <fixposition_gnss_tf/gnss_tf.hpp>
@@ -41,6 +42,7 @@ FixpositionDriverNode::FixpositionDriverNode(const FixpositionDriverParams& para
       navsatfix_pub_(nh_.advertise<sensor_msgs::NavSatFix>("/fixposition/navsatfix", 100)),
       navsatfix_gnss1_pub_(nh_.advertise<sensor_msgs::NavSatFix>("/fixposition/gnss1", 100)),
       navsatfix_gnss2_pub_(nh_.advertise<sensor_msgs::NavSatFix>("/fixposition/gnss2", 100)),
+      navsatfix_gpgga_pub_(nh_.advertise<sensor_msgs::NavSatFix>("/fixposition/gpgga", 100)),
       //   ODOMETRY
       odometry_pub_(nh_.advertise<nav_msgs::Odometry>("/fixposition/odometry", 100)),
       poiimu_pub_(nh_.advertise<sensor_msgs::Imu>("/fixposition/poiimu", 100)),
@@ -152,6 +154,15 @@ void FixpositionDriverNode::RegisterObservers() {
 
                 } else {
                     static_br_.sendTransform(tf);
+                }
+            });
+        } else if (format == "GPGGA") {
+            dynamic_cast<GpggaConverter*>(a_converters_["GPGGA"].get())->AddObserver([this](const NavSatFixData& data) {
+                // GPGGA Observer Lambda
+                if (navsatfix_gpgga_pub_.getNumSubscribers() > 0) {
+                    sensor_msgs::NavSatFix msg;
+                    NavSatFixDataToMsg(data, msg);
+                    navsatfix_gpgga_pub_.publish(msg);
                 }
             });
         }

--- a/fixposition_driver_ros2/CMakeLists.txt
+++ b/fixposition_driver_ros2/CMakeLists.txt
@@ -26,6 +26,7 @@ find_package(fixposition_driver_lib REQUIRED)
 rosidl_generate_interfaces(${PROJECT_NAME}
   msg/VRTK.msg
   msg/Speed.msg
+  msg/NMEA.msg
   DEPENDENCIES
   std_msgs
   nav_msgs

--- a/fixposition_driver_ros2/include/fixposition_driver_ros2/data_to_ros2.hpp
+++ b/fixposition_driver_ros2/include/fixposition_driver_ros2/data_to_ros2.hpp
@@ -37,6 +37,7 @@
 
 /* PACKAGE */
 #include <fixposition_driver_ros2/msg/vrtk.hpp>
+#include <fixposition_driver_ros2/msg/nmea.hpp>
 
 namespace fixposition {
 

--- a/fixposition_driver_ros2/include/fixposition_driver_ros2/fixposition_driver_node.hpp
+++ b/fixposition_driver_ros2/include/fixposition_driver_ros2/fixposition_driver_node.hpp
@@ -60,6 +60,9 @@ class FixpositionDriverNode : public FixpositionDriver {
         GpzdaData gpzda;
         GprmcData gprmc;
         
+        /**
+         * @brief Check if GNSS epoch is complete
+         */
         bool checkEpoch() {
             if ((gpgga.time.compare(gpzda.time) == 0) && (gpgga.time.compare(gprmc.time) == 0)) {
                 return true;
@@ -78,6 +81,11 @@ class FixpositionDriverNode : public FixpositionDriver {
      */
     void BestGnssPosToPublishNavSatFix(const Oem7MessageHeaderMem* header, const BESTGNSSPOSMem* payload);
 
+    /**
+     * @brief Observer Function to publish NMEA message from GPGGA, GPRMC, and GPZDA once the GNSS epoch transmission is complete
+     *
+     * @param[in] data
+     */
     void PublishNmea(NmeaMessage data);
     
     std::shared_ptr<rclcpp::Node> node_;

--- a/fixposition_driver_ros2/include/fixposition_driver_ros2/fixposition_driver_node.hpp
+++ b/fixposition_driver_ros2/include/fixposition_driver_ros2/fixposition_driver_node.hpp
@@ -55,6 +55,20 @@ class FixpositionDriverNode : public FixpositionDriver {
 
     void WsCallback(const fixposition_driver_ros2::msg::Speed::ConstSharedPtr msg);
 
+    struct NmeaMessage {
+        GpggaData gpgga;
+        GpzdaData gpzda;
+        GprmcData gprmc;
+        
+        bool checkEpoch() {
+            if ((gpgga.time.compare(gpzda.time) == 0) && (gpgga.time.compare(gprmc.time) == 0)) {
+                return true;
+            } else {
+                return false;
+            }
+        }  
+    };
+
    private:
     /**
      * @brief Observer Functions to publish NavSatFix from BestGnssPos
@@ -72,7 +86,7 @@ class FixpositionDriverNode : public FixpositionDriver {
     rclcpp::Publisher<sensor_msgs::msg::NavSatFix>::SharedPtr navsatfix_pub_;
     rclcpp::Publisher<sensor_msgs::msg::NavSatFix>::SharedPtr navsatfix_gnss1_pub_;
     rclcpp::Publisher<sensor_msgs::msg::NavSatFix>::SharedPtr navsatfix_gnss2_pub_;
-    rclcpp::Publisher<sensor_msgs::msg::NavSatFix>::SharedPtr navsatfix_gpgga_pub_;
+    rclcpp::Publisher<fixposition_driver_ros2::msg::NMEA>::SharedPtr nmea_pub_;
     rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr odometry_pub_;
     rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr poiimu_pub_;             //!< Bias corrected IMU from ODOMETRY
     rclcpp::Publisher<fixposition_driver_ros2::msg::VRTK>::SharedPtr vrtk_pub_;  //!< VRTK message
@@ -84,6 +98,8 @@ class FixpositionDriverNode : public FixpositionDriver {
 
     std::shared_ptr<tf2_ros::TransformBroadcaster> br_;
     std::shared_ptr<tf2_ros::StaticTransformBroadcaster> static_br_;
+
+    NmeaMessage nmea_message_;
 };
 
 }  // namespace fixposition

--- a/fixposition_driver_ros2/include/fixposition_driver_ros2/fixposition_driver_node.hpp
+++ b/fixposition_driver_ros2/include/fixposition_driver_ros2/fixposition_driver_node.hpp
@@ -72,6 +72,7 @@ class FixpositionDriverNode : public FixpositionDriver {
     rclcpp::Publisher<sensor_msgs::msg::NavSatFix>::SharedPtr navsatfix_pub_;
     rclcpp::Publisher<sensor_msgs::msg::NavSatFix>::SharedPtr navsatfix_gnss1_pub_;
     rclcpp::Publisher<sensor_msgs::msg::NavSatFix>::SharedPtr navsatfix_gnss2_pub_;
+    rclcpp::Publisher<sensor_msgs::msg::NavSatFix>::SharedPtr navsatfix_gpgga_pub_;
     rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr odometry_pub_;
     rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr poiimu_pub_;             //!< Bias corrected IMU from ODOMETRY
     rclcpp::Publisher<fixposition_driver_ros2::msg::VRTK>::SharedPtr vrtk_pub_;  //!< VRTK message

--- a/fixposition_driver_ros2/include/fixposition_driver_ros2/fixposition_driver_node.hpp
+++ b/fixposition_driver_ros2/include/fixposition_driver_ros2/fixposition_driver_node.hpp
@@ -77,6 +77,8 @@ class FixpositionDriverNode : public FixpositionDriver {
      * @param[in] payload
      */
     void BestGnssPosToPublishNavSatFix(const Oem7MessageHeaderMem* header, const BESTGNSSPOSMem* payload);
+
+    void PublishNmea(NmeaMessage data);
     
     std::shared_ptr<rclcpp::Node> node_;
     rclcpp::Subscription<fixposition_driver_ros2::msg::Speed>::SharedPtr ws_sub_;  //!< wheelspeed message subscriber

--- a/fixposition_driver_ros2/launch/tcp.yaml
+++ b/fixposition_driver_ros2/launch/tcp.yaml
@@ -1,7 +1,7 @@
 fixposition_driver_ros2:
   ros__parameters:
     fp_output:
-      formats: ["ODOMETRY", "LLH", "RAWIMU", "CORRIMU", "TF"]
+      formats: ["ODOMETRY", "LLH", "RAWIMU", "CORRIMU", "GPGGA", "GPZDA", "GPRMC", "TF"]
       type: "tcp"
       port: "21000"
       ip: "10.0.2.1" # change to VRTK2's IP address in the network

--- a/fixposition_driver_ros2/msg/NMEA.msg
+++ b/fixposition_driver_ros2/msg/NMEA.msg
@@ -1,0 +1,66 @@
+####################################################################################################
+#
+#    Copyright (c) 2023  ___     ___
+#                       \\  \\  /  /
+#                        \\  \\/  /
+#                         /  /\\  \\
+#                        /__/  \\__\\  Fixposition AG
+#
+####################################################################################################
+#
+# Fixposition NMEA Message
+#
+#
+####################################################################################################
+
+# Navigation Satellite fix for any Global Navigation Satellite System
+#
+# Specified using the WGS 84 reference ellipsoid
+
+# header.stamp specifies the ROS time for this measurement (the
+#        corresponding satellite time may be reported using the
+#        sensor_msgs/TimeReference message).
+#
+# header.frame_id is the frame of reference reported by the satellite
+#        receiver, usually the location of the antenna.  This is a
+#        Euclidean frame relative to the vehicle, not a reference
+#        ellipsoid.
+Header header
+
+# Latitude [degrees]. Positive is north of equator; negative is south.
+float64 latitude
+
+# Longitude [degrees]. Positive is east of prime meridian; negative is west.
+float64 longitude
+
+# Altitude [m]. Positive is above the WGS 84 ellipsoid.
+float64 altitude
+
+# Speed over ground [m/s]
+float64 speed
+
+# Course over ground [deg]
+float64 course
+
+# Position covariance [m^2] defined relative to a tangential plane
+# through the reported position. The components are East, North, and
+# Up (ENU), in row-major order.
+#
+# Beware: this coordinate system exhibits singularities at the poles.
+
+float64[9] position_covariance
+
+# If the covariance of the fix is known, fill it in completely. If the
+# GPS receiver provides the variance of each measurement, put them
+# along the diagonal. If only Dilution of Precision is available,
+# estimate an approximate covariance from that.
+
+uint8 COVARIANCE_TYPE_UNKNOWN = 0
+uint8 COVARIANCE_TYPE_APPROXIMATED = 1
+uint8 COVARIANCE_TYPE_DIAGONAL_KNOWN = 2
+uint8 COVARIANCE_TYPE_KNOWN = 3
+
+uint8 position_covariance_type
+
+# Positioning system mode indicator, R (RTK fixed), F (RTK float), A (no RTK), E, N
+string mode

--- a/fixposition_driver_ros2/msg/NMEA.msg
+++ b/fixposition_driver_ros2/msg/NMEA.msg
@@ -1,10 +1,7 @@
 ####################################################################################################
 #
-#    Copyright (c) 2023  ___     ___
-#                       \\  \\  /  /
-#                        \\  \\/  /
-#                         /  /\\  \\
-#                        /__/  \\__\\  Fixposition AG
+#    Copyright (c) 2023
+#    Fixposition AG
 #
 ####################################################################################################
 #
@@ -25,7 +22,7 @@
 #        receiver, usually the location of the antenna.  This is a
 #        Euclidean frame relative to the vehicle, not a reference
 #        ellipsoid.
-Header header
+std_msgs/Header header
 
 # Latitude [degrees]. Positive is north of equator; negative is south.
 float64 latitude

--- a/fixposition_driver_ros2/src/fixposition_driver_node.cpp
+++ b/fixposition_driver_ros2/src/fixposition_driver_node.cpp
@@ -190,7 +190,7 @@ void FixpositionDriverNode::RegisterObservers() {
         } else if (format == "GPGGA") {
             dynamic_cast<GpggaConverter*>(a_converters_["GPGGA"].get())->AddObserver([this](const GpggaData& data) {
                 // GPGGA Observer Lambda
-                if (nmea_pub_.getNumSubscribers() > 0) {
+                if (nmea_pub_->get_subscription_count() > 0) {
                     nmea_message_.gpgga = data;
                     PublishNmea(nmea_message_);
                 }
@@ -198,7 +198,7 @@ void FixpositionDriverNode::RegisterObservers() {
         } else if (format == "GPZDA") {
             dynamic_cast<GpzdaConverter*>(a_converters_["GPZDA"].get())->AddObserver([this](const GpzdaData& data) {
                 // GPZDA Observer Lambda
-                if (nmea_pub_.getNumSubscribers() > 0) {
+                if (nmea_pub_->get_subscription_count() > 0) {
                     nmea_message_.gpzda = data;
                     PublishNmea(nmea_message_);
                 }
@@ -206,7 +206,7 @@ void FixpositionDriverNode::RegisterObservers() {
         } else if (format == "GPRMC") {
             dynamic_cast<GprmcConverter*>(a_converters_["GPRMC"].get())->AddObserver([this](const GprmcData& data) {
                 // GPRMC Observer Lambda
-                if (nmea_pub_.getNumSubscribers() > 0) {
+                if (nmea_pub_->get_subscription_count() > 0) {
                     nmea_message_.gprmc = data;
                     PublishNmea(nmea_message_);
                 }
@@ -219,10 +219,10 @@ void FixpositionDriverNode::PublishNmea(NmeaMessage data) {
     // If epoch message is complete, generate NMEA output
     if (data.checkEpoch()) {
         // Generate new message
-        fixposition_driver_ros1::NMEA msg;
+        fixposition_driver_ros2::msg::NMEA msg;
         
         // ROS Header
-        msg.header.stamp = ros::Time::fromBoost(GpsTimeToPtime(data.gpzda.stamp));
+        msg.header.stamp = GpsTimeToMsgTime(data.gpzda.stamp);
         msg.header.frame_id = "LLH";
         
         // Latitude [degrees]. Positive is north of equator; negative is south
@@ -251,7 +251,7 @@ void FixpositionDriverNode::PublishNmea(NmeaMessage data) {
         msg.mode = data.gprmc.mode;
         
         // Publish message
-        nmea_pub_.publish(msg);
+        nmea_pub_->publish(msg);
     }
 }
 

--- a/fixposition_driver_ros2/src/fixposition_driver_node.cpp
+++ b/fixposition_driver_ros2/src/fixposition_driver_node.cpp
@@ -24,6 +24,7 @@
 #include <fixposition_driver_lib/converter/llh.hpp>
 #include <fixposition_driver_lib/converter/odometry.hpp>
 #include <fixposition_driver_lib/converter/tf.hpp>
+#include <fixposition_driver_lib/converter/gpgga.hpp>
 #include <fixposition_driver_lib/fixposition_driver.hpp>
 #include <fixposition_driver_lib/helper.hpp>
 #include <fixposition_gnss_tf/gnss_tf.hpp>
@@ -43,6 +44,7 @@ FixpositionDriverNode::FixpositionDriverNode(std::shared_ptr<rclcpp::Node> node,
       navsatfix_pub_(node_->create_publisher<sensor_msgs::msg::NavSatFix>("/fixposition/navsatfix", 100)),
       navsatfix_gnss1_pub_(node_->create_publisher<sensor_msgs::msg::NavSatFix>("/fixposition/gnss1", 100)),
       navsatfix_gnss2_pub_(node_->create_publisher<sensor_msgs::msg::NavSatFix>("/fixposition/gnss2", 100)),
+      navsatfix_gpgga_pub_(node_->create_publisher<sensor_msgs::msg::NavSatFix>("/fixposition/gpgga", 100)),
       odometry_pub_(node_->create_publisher<nav_msgs::msg::Odometry>("/fixposition/odometry", 100)),
       poiimu_pub_(node_->create_publisher<sensor_msgs::msg::Imu>("/fixposition/poiimu", 100)),
       vrtk_pub_(node_->create_publisher<fixposition_driver_ros2::msg::VRTK>("/fixposition/vrtk", 100)),
@@ -181,6 +183,15 @@ void FixpositionDriverNode::RegisterObservers() {
 
                 } else {
                     static_br_->sendTransform(tf);
+                }
+            });
+        } else if (format == "GPGGA") {
+            dynamic_cast<GpggaConverter*>(a_converters_["GPGGA"].get())->AddObserver([this](const NavSatFixData& data) {
+                // GPGGA Observer Lambda
+                if (navsatfix_gpgga_pub_.getNumSubscribers() > 0) {
+                    sensor_msgs::NavSatFix msg;
+                    NavSatFixDataToMsg(data, msg);
+                    navsatfix_gpgga_pub_.publish(msg);
                 }
             });
         }

--- a/fixposition_driver_ros2/src/fixposition_driver_node.cpp
+++ b/fixposition_driver_ros2/src/fixposition_driver_node.cpp
@@ -25,6 +25,8 @@
 #include <fixposition_driver_lib/converter/odometry.hpp>
 #include <fixposition_driver_lib/converter/tf.hpp>
 #include <fixposition_driver_lib/converter/gpgga.hpp>
+#include <fixposition_driver_lib/converter/gpzda.hpp>
+#include <fixposition_driver_lib/converter/gprmc.hpp>
 #include <fixposition_driver_lib/fixposition_driver.hpp>
 #include <fixposition_driver_lib/helper.hpp>
 #include <fixposition_gnss_tf/gnss_tf.hpp>
@@ -44,7 +46,7 @@ FixpositionDriverNode::FixpositionDriverNode(std::shared_ptr<rclcpp::Node> node,
       navsatfix_pub_(node_->create_publisher<sensor_msgs::msg::NavSatFix>("/fixposition/navsatfix", 100)),
       navsatfix_gnss1_pub_(node_->create_publisher<sensor_msgs::msg::NavSatFix>("/fixposition/gnss1", 100)),
       navsatfix_gnss2_pub_(node_->create_publisher<sensor_msgs::msg::NavSatFix>("/fixposition/gnss2", 100)),
-      navsatfix_gpgga_pub_(node_->create_publisher<sensor_msgs::msg::NavSatFix>("/fixposition/gpgga", 100)),
+      nmea_pub_(node_->create_publisher<fixposition_driver_ros2::msg::NMEA>("/fixposition/nmea", 100)),
       odometry_pub_(node_->create_publisher<nav_msgs::msg::Odometry>("/fixposition/odometry", 100)),
       poiimu_pub_(node_->create_publisher<sensor_msgs::msg::Imu>("/fixposition/poiimu", 100)),
       vrtk_pub_(node_->create_publisher<fixposition_driver_ros2::msg::VRTK>("/fixposition/vrtk", 100)),
@@ -186,15 +188,70 @@ void FixpositionDriverNode::RegisterObservers() {
                 }
             });
         } else if (format == "GPGGA") {
-            dynamic_cast<GpggaConverter*>(a_converters_["GPGGA"].get())->AddObserver([this](const NavSatFixData& data) {
+            dynamic_cast<GpggaConverter*>(a_converters_["GPGGA"].get())->AddObserver([this](const GpggaData& data) {
                 // GPGGA Observer Lambda
-                if (navsatfix_gpgga_pub_.getNumSubscribers() > 0) {
-                    sensor_msgs::NavSatFix msg;
-                    NavSatFixDataToMsg(data, msg);
-                    navsatfix_gpgga_pub_.publish(msg);
+                if (nmea_pub_.getNumSubscribers() > 0) {
+                    nmea_message_.gpgga = data;
+                    PublishNmea(nmea_message_);
+                }
+            });
+        } else if (format == "GPZDA") {
+            dynamic_cast<GpzdaConverter*>(a_converters_["GPZDA"].get())->AddObserver([this](const GpzdaData& data) {
+                // GPZDA Observer Lambda
+                if (nmea_pub_.getNumSubscribers() > 0) {
+                    nmea_message_.gpzda = data;
+                    PublishNmea(nmea_message_);
+                }
+            });
+        } else if (format == "GPRMC") {
+            dynamic_cast<GprmcConverter*>(a_converters_["GPRMC"].get())->AddObserver([this](const GprmcData& data) {
+                // GPRMC Observer Lambda
+                if (nmea_pub_.getNumSubscribers() > 0) {
+                    nmea_message_.gprmc = data;
+                    PublishNmea(nmea_message_);
                 }
             });
         }
+    }
+}
+
+void FixpositionDriverNode::PublishNmea(NmeaMessage data) {
+    // If epoch message is complete, generate NMEA output
+    if (data.checkEpoch()) {
+        // Generate new message
+        fixposition_driver_ros1::NMEA msg;
+        
+        // ROS Header
+        msg.header.stamp = ros::Time::fromBoost(GpsTimeToPtime(data.gpzda.stamp));
+        msg.header.frame_id = "LLH";
+        
+        // Latitude [degrees]. Positive is north of equator; negative is south
+        msg.latitude = data.gpgga.latitude;
+        
+        // Longitude [degrees]. Positive is east of prime meridian; negative is west
+        msg.longitude = data.gpgga.longitude;
+        
+        // Altitude [m]. Positive is above the WGS 84 ellipsoid
+        msg.altitude = data.gpgga.altitude;
+
+        // Speed over ground [m/s]
+        msg.speed = data.gprmc.speed;
+        
+        // Course over ground [deg]
+        msg.course = data.gprmc.course;
+
+        // TODO: Get better position covariance from NMEA-GP-GST
+        // Position covariance [m^2]
+        Eigen::Map<Eigen::Matrix<double, 3, 3>> cov_map =
+            Eigen::Map<Eigen::Matrix<double, 3, 3>>(msg.position_covariance.data());
+        cov_map = data.gpgga.cov;
+        msg.position_covariance_type = data.gpgga.position_covariance_type;
+
+        // Positioning system mode indicator, R (RTK fixed), F (RTK float), A (no RTK), E, N
+        msg.mode = data.gprmc.mode;
+        
+        // Publish message
+        nmea_pub_.publish(msg);
     }
 }
 


### PR DESCRIPTION
Added new NMEA.msg and /fixposition/nmea topic which includes the following information:

- GPS time
- LLH position
- Speed over ground
- Course over ground
- Fix quality

This is based on NMEA messages which are generated from GNSS data only before Fusion is initialized. This serves as an approximation until the Fusion engine is initialized.

The user must enable the GP-GGA, GP-RMC, and GP-ZDA messages for this output to work.

**ROS2 implementation is still pending.**