### PR TITLE
Smooth odometry support

### DIFF
--- a/fixposition_driver_lib/src/fixposition_driver.cpp
+++ b/fixposition_driver_lib/src/fixposition_driver.cpp
@@ -312,6 +312,9 @@ void FixpositionDriver::NmeaConvertAndPublish(const std::string& msg) {
 
     // If we have a converter available, convert to ros.
     // Currently supported are "FP", "LLH", "ODOMETRY", "ODOMSH", "TF", "RAWIMU", "CORRIMU"
+    if (header == "ODOMSH") {
+        tokens.push_back("");
+    }
     if (a_converters_[header] != nullptr) {
         a_converters_[header]->ConvertTokens(tokens);
     }

--- a/fixposition_driver_lib/src/fixposition_driver.cpp
+++ b/fixposition_driver_lib/src/fixposition_driver.cpp
@@ -287,7 +287,6 @@ bool FixpositionDriver::ReadAndPublish() {
 
 void FixpositionDriver::NmeaConvertAndPublish(const std::string& msg) {
     // split the msg into tokens, removing the *XX checksum
-    std::cout << "Converting msg: " << msg << std::endl;
     std::vector<std::string> tokens;
     std::size_t star_pos = msg.find_last_of("*");
     SplitMessage(tokens, msg.substr(1, star_pos - 1), ",");
@@ -313,7 +312,7 @@ void FixpositionDriver::NmeaConvertAndPublish(const std::string& msg) {
     // If we have a converter available, convert to ros.
     // Currently supported are "FP", "LLH", "ODOMETRY", "ODOMSH", "TF", "RAWIMU", "CORRIMU"
 
-    // The odomsh does not seem to contain the firmware version
+    // The odomsh does not seem to contain the firmware version, and has the wrong number of fields.
     if (header == "ODOMSH") {
         tokens[2] = "2";
         tokens.push_back("");

--- a/fixposition_driver_lib/src/fixposition_driver.cpp
+++ b/fixposition_driver_lib/src/fixposition_driver.cpp
@@ -315,7 +315,8 @@ void FixpositionDriver::NmeaConvertAndPublish(const std::string& msg) {
 
     // The odomsh does not seem to contain the firmware version
     if (header == "ODOMSH") {
-        tokens.push_back("2");
+        tokens[2] = "2";
+        tokens.push_back("");
     }
     if (a_converters_[header] != nullptr) {
         a_converters_[header]->ConvertTokens(tokens);

--- a/fixposition_driver_lib/src/fixposition_driver.cpp
+++ b/fixposition_driver_lib/src/fixposition_driver.cpp
@@ -311,7 +311,9 @@ void FixpositionDriver::NmeaConvertAndPublish(const std::string& msg) {
 
     // If we have a converter available, convert to ros.
     // Currently supported are "FP", "LLH", "ODOMETRY", "ODOMSH", "TF", "RAWIMU", "CORRIMU"
+    std::cout << "Got message: " << header << "\n";
     if (a_converters_[header] != nullptr) {
+        std::cout << "Converting message \n";
         a_converters_[header]->ConvertTokens(tokens);
     }
 }

--- a/fixposition_driver_lib/src/fixposition_driver.cpp
+++ b/fixposition_driver_lib/src/fixposition_driver.cpp
@@ -312,8 +312,10 @@ void FixpositionDriver::NmeaConvertAndPublish(const std::string& msg) {
 
     // If we have a converter available, convert to ros.
     // Currently supported are "FP", "LLH", "ODOMETRY", "ODOMSH", "TF", "RAWIMU", "CORRIMU"
+
+    // The odomsh does not seem to contain the firmware version
     if (header == "ODOMSH") {
-        tokens.push_back("");
+        tokens.push_back("2");
     }
     if (a_converters_[header] != nullptr) {
         a_converters_[header]->ConvertTokens(tokens);

--- a/fixposition_driver_lib/src/fixposition_driver.cpp
+++ b/fixposition_driver_lib/src/fixposition_driver.cpp
@@ -185,6 +185,8 @@ bool FixpositionDriver::InitializeConverters() {
         if (format == "ODOMETRY") {
             a_converters_["ODOMETRY"] = std::unique_ptr<OdometryConverter>(new OdometryConverter());
             a_converters_["TF"] = std::unique_ptr<TfConverter>(new TfConverter());
+        } else if (format == "ODOMSH") {
+            a_converters_["ODOMSH"] = std::unique_ptr<OdometryConverter>(new OdometryConverter());
         } else if (format == "LLH") {
             a_converters_["LLH"] = std::unique_ptr<LlhConverter>(new LlhConverter());
         } else if (format == "RAWIMU") {
@@ -307,7 +309,8 @@ void FixpositionDriver::NmeaConvertAndPublish(const std::string& msg) {
     }
     const std::string header = _header;
 
-    // If we have a converter available, convert to ros. Currently supported are "FP", "LLH", "TF", "RAWIMU", "CORRIMU"
+    // If we have a converter available, convert to ros.
+    // Currently supported are "FP", "LLH", "ODOMETRY", "ODOMSH", "TF", "RAWIMU", "CORRIMU"
     if (a_converters_[header] != nullptr) {
         a_converters_[header]->ConvertTokens(tokens);
     }

--- a/fixposition_driver_lib/src/fixposition_driver.cpp
+++ b/fixposition_driver_lib/src/fixposition_driver.cpp
@@ -287,6 +287,7 @@ bool FixpositionDriver::ReadAndPublish() {
 
 void FixpositionDriver::NmeaConvertAndPublish(const std::string& msg) {
     // split the msg into tokens, removing the *XX checksum
+    std::cout << "Converting msg: " << msg << std::endl;
     std::vector<std::string> tokens;
     std::size_t star_pos = msg.find_last_of("*");
     SplitMessage(tokens, msg.substr(1, star_pos - 1), ",");
@@ -311,9 +312,7 @@ void FixpositionDriver::NmeaConvertAndPublish(const std::string& msg) {
 
     // If we have a converter available, convert to ros.
     // Currently supported are "FP", "LLH", "ODOMETRY", "ODOMSH", "TF", "RAWIMU", "CORRIMU"
-    std::cout << "Got message: " << header << "\n";
     if (a_converters_[header] != nullptr) {
-        std::cout << "Converting message \n";
         a_converters_[header]->ConvertTokens(tokens);
     }
 }

--- a/fixposition_driver_lib/src/odometry.cpp
+++ b/fixposition_driver_lib/src/odometry.cpp
@@ -101,7 +101,7 @@ void OdometryConverter::ConvertTokens(const std::vector<std::string>& tokens) {
         ok = version == kVersion_;
         if (!ok) {
             // Version is wrong
-            std::cout << "Error in parsing Odometry string with verion " << version
+            std::cout << "Error in parsing Odometry string with version " << version
                       << " ! Odometry and status messages will be empty.\n";
         }
     }

--- a/fixposition_driver_lib/src/odometry.cpp
+++ b/fixposition_driver_lib/src/odometry.cpp
@@ -92,6 +92,7 @@ void OdometryConverter::ConvertTokens(const std::vector<std::string>& tokens) {
         // Size is wrong
         std::cout << "Error in parsing Odometry string with " << tokens.size()
                   << " fields! Odometry and status messages will be empty.\n";
+        
 
     } else {
         // If size is ok, check version

--- a/fixposition_driver_ros2/include/fixposition_driver_ros2/fixposition_driver_node.hpp
+++ b/fixposition_driver_ros2/include/fixposition_driver_ros2/fixposition_driver_node.hpp
@@ -102,6 +102,7 @@ class FixpositionDriverNode : public FixpositionDriver {
     rclcpp::Publisher<sensor_msgs::msg::NavSatFix>::SharedPtr navsatfix_gnss2_pub_;
     rclcpp::Publisher<fixposition_driver_ros2::msg::NMEA>::SharedPtr nmea_pub_;
     rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr odometry_pub_;
+    rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr odometry_smooth_pub_;
     rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr poiimu_pub_;             //!< Bias corrected IMU from ODOMETRY
     rclcpp::Publisher<fixposition_driver_ros2::msg::VRTK>::SharedPtr vrtk_pub_;  //!< VRTK message
     rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr odometry_enu0_pub_;    //!< ENU0 Odometry

--- a/fixposition_driver_ros2/src/fixposition_driver_node.cpp
+++ b/fixposition_driver_ros2/src/fixposition_driver_node.cpp
@@ -48,6 +48,7 @@ FixpositionDriverNode::FixpositionDriverNode(std::shared_ptr<rclcpp::Node> node,
       navsatfix_gnss2_pub_(node_->create_publisher<sensor_msgs::msg::NavSatFix>("/fixposition/gnss2", 100)),
       nmea_pub_(node_->create_publisher<fixposition_driver_ros2::msg::NMEA>("/fixposition/nmea", 100)),
       odometry_pub_(node_->create_publisher<nav_msgs::msg::Odometry>("/fixposition/odometry", 100)),
+      odometry_smooth_pub_(node_->create_publisher<nav_msgs::msg::Odometry>("/fixposition/odomsh", 100)),
       poiimu_pub_(node_->create_publisher<sensor_msgs::msg::Imu>("/fixposition/poiimu", 100)),
       vrtk_pub_(node_->create_publisher<fixposition_driver_ros2::msg::VRTK>("/fixposition/vrtk", 100)),
       odometry_enu0_pub_(node_->create_publisher<nav_msgs::msg::Odometry>("/fixposition/odometry_enu", 100)),
@@ -144,6 +145,15 @@ void FixpositionDriverNode::RegisterObservers() {
                         br_->sendTransform(tf_ecef_enu);
                         br_->sendTransform(tf_ecef_poi);
                         static_br_->sendTransform(tf_ecef_enu0);
+                    }
+                });
+        } else if (format == "ODOMSH") {
+            dynamic_cast<OdometryConverter*>(a_converters_["ODOMSH"].get())
+                ->AddObserver([this](const OdometryConverter::Msgs& data) {
+                    if (odometry_smooth_pub_->get_subscription_count() > 0) {
+                        nav_msgs::msg::Odometry odometry;
+                        OdometryDataToMsg(data.odometry, odometry);
+                        odometry_pub_->publish(odometry);
                     }
                 });
         } else if (format == "LLH" && a_converters_["LLH"]) {

--- a/fixposition_driver_ros2/src/fixposition_driver_node.cpp
+++ b/fixposition_driver_ros2/src/fixposition_driver_node.cpp
@@ -153,7 +153,7 @@ void FixpositionDriverNode::RegisterObservers() {
                     if (odometry_smooth_pub_->get_subscription_count() > 0) {
                         nav_msgs::msg::Odometry odometry;
                         OdometryDataToMsg(data.odometry, odometry);
-                        odometry_pub_->publish(odometry);
+                        odometry_smooth_pub_->publish(odometry);
                     }
                 });
         } else if (format == "LLH" && a_converters_["LLH"]) {


### PR DESCRIPTION
This is the minimal changes to allow publishing of smooth odometry when enabled. Reverse-engineering the message, I noticed a missing last field (firmware name/version) and a different version in the 3 token. 

Otherwise the message definition seems compliant with the odometry message and the converter seems to work fine also for ODOMSH. 

Sharing in case this could be improved or taken as starting point for production ready integration of ODOMSH. 