### PR TITLE
Optional tf publishing of odometry

### DIFF
--- a/fixposition_driver_lib/include/fixposition_driver_lib/params.hpp
+++ b/fixposition_driver_lib/include/fixposition_driver_lib/params.hpp
@@ -33,9 +33,10 @@ struct FpOutputParams {
     INPUT_TYPE type;                   //!< TCP or SERIAL
     std::vector<std::string> formats;  //!< data formats to convert, support "FP" and "LLH" for now
 
-    std::string ip;    //!< IP address for TCP connection
-    std::string port;  //!< Port for TCP connection
-    int baudrate;      //!< baudrate of serial connection
+    std::string ip;        //!< IP address for TCP connection
+    std::string port;      //!< Port for TCP connection
+    int baudrate;          //!< baudrate of serial connection
+    bool publish_odom_tf;  //!< publish odometry also as transformations between frames
 };
 struct CustomerInputParams {
     std::string speed_topic;

--- a/fixposition_driver_ros1/src/fixposition_driver_node.cpp
+++ b/fixposition_driver_ros1/src/fixposition_driver_node.cpp
@@ -109,7 +109,7 @@ void FixpositionDriverNode::RegisterObservers() {
                     }
 
                     // TFs
-                    if (data.vrtk.fusion_status > 0) {
+                    if (data.vrtk.fusion_status > 0 && params_.fp_output.publish_odom_tf) {
                         geometry_msgs::TransformStamped tf_ecef_poi;
                         geometry_msgs::TransformStamped tf_ecef_enu;
                         geometry_msgs::TransformStamped tf_ecef_enu0;

--- a/fixposition_driver_ros1/src/params.cpp
+++ b/fixposition_driver_ros1/src/params.cpp
@@ -29,6 +29,8 @@ bool LoadParamsFromRos1(const std::string& ns, FpOutputParams& params) {
     const std::string IP = ns + "/ip";
     const std::string PORT = ns + "/port";
     const std::string BAUDRATE = ns + "/baudrate";
+    const std::string PUBLISH_ODOM_TF = ns + "/publish_odom_tf";
+
     // read parameters
     if (!ros::param::get(RATE, params.rate)) {
         params.rate = 100;
@@ -84,6 +86,14 @@ bool LoadParamsFromRos1(const std::string& ns, FpOutputParams& params) {
         }
         ROS_INFO("%s : %d", BAUDRATE.c_str(), params.baudrate);
         ROS_INFO("%s : %s", PORT.c_str(), params.port.c_str());
+    }
+
+    if (!ros::param::get(PUBLISH_ODOM_TF, params.publish_odom_tf)) {
+        // default value is to publish odometry as transformations
+        params.publish_odom_tf = true;
+        ROS_WARN("Using Default Publish Odom TF : %d", params.publish_odom_tf);
+    } else {
+        ROS_INFO("%s : %s", PUBLISH_ODOM_TF.c_str(), params.publish_odom_tf ? "true" : "false");
     }
 
     return true;

--- a/fixposition_driver_ros2/src/fixposition_driver_node.cpp
+++ b/fixposition_driver_ros2/src/fixposition_driver_node.cpp
@@ -134,7 +134,7 @@ void FixpositionDriverNode::RegisterObservers() {
                     }
 
                     // TFs
-                    if (data.vrtk.fusion_status > 0) {
+                    if (data.vrtk.fusion_status > 0 && params_.fp_output.publish_odom_tf) {
                         geometry_msgs::msg::TransformStamped tf_ecef_poi;
                         geometry_msgs::msg::TransformStamped tf_ecef_enu;
                         geometry_msgs::msg::TransformStamped tf_ecef_enu0;

--- a/fixposition_driver_ros2/src/params.cpp
+++ b/fixposition_driver_ros2/src/params.cpp
@@ -88,10 +88,10 @@ bool LoadParamsFromRos2(std::shared_ptr<rclcpp::Node> node, const std::string& n
     }
 
     if (node->get_parameter(PUBLISH_ODOM_TF, params.publish_odom_tf)) {
-        RCLCPP_INFO(node->get_logger(), "%s : %s", PUBLISH_ODOM_TF.c_str(), params.publish_odom_tf.c_str());
+        RCLCPP_INFO(node->get_logger(), "%s : %s", PUBLISH_ODOM_TF.c_str(), params.publish_odom_tf ? "true" : "false");
     } else {
         RCLCPP_WARN(node->get_logger(), "Using Default %s : %s", PUBLISH_ODOM_TF.c_str(),
-                    params.publish_odom_tf.c_str());
+                    params.publish_odom_tf ? "true" : "false");
     }
 
     return true;

--- a/fixposition_driver_ros2/src/params.cpp
+++ b/fixposition_driver_ros2/src/params.cpp
@@ -28,6 +28,7 @@ bool LoadParamsFromRos2(std::shared_ptr<rclcpp::Node> node, const std::string& n
     const std::string IP = ns + ".ip";
     const std::string PORT = ns + ".port";
     const std::string BAUDRATE = ns + ".baudrate";
+    const std::string PUBLISH_ODOM_TF = ns + ".publish_odom_tf";
 
     node->declare_parameter(RATE, 100);
     node->declare_parameter(RECONNECT_DELAY, 5.0);
@@ -36,6 +37,7 @@ bool LoadParamsFromRos2(std::shared_ptr<rclcpp::Node> node, const std::string& n
     node->declare_parameter(PORT, "21000");
     node->declare_parameter(IP, "127.0.0.1");
     node->declare_parameter(BAUDRATE, 115200);
+    node->declare_parameter(PUBLISH_ODOM_TF, true);
     // read parameters
     if (node->get_parameter(RATE, params.rate)) {
         RCLCPP_INFO(node->get_logger(), "%s : %d", RATE.c_str(), params.rate);
@@ -83,6 +85,13 @@ bool LoadParamsFromRos2(std::shared_ptr<rclcpp::Node> node, const std::string& n
         } else {
             RCLCPP_WARN(node->get_logger(), "Using Default %s : %d", BAUDRATE.c_str(), params.baudrate);
         }
+    }
+
+    if (node->get_parameter(PUBLISH_ODOM_TF, params.publish_odom_tf)) {
+        RCLCPP_INFO(node->get_logger(), "%s : %s", PUBLISH_ODOM_TF.c_str(), params.publish_odom_tf.c_str());
+    } else {
+        RCLCPP_WARN(node->get_logger(), "Using Default %s : %s", PUBLISH_ODOM_TF.c_str(),
+                    params.publish_odom_tf.c_str());
     }
 
     return true;


### PR DESCRIPTION
We have observed, after the last firmware updates (5.83.x), that at times NaNs are published in the transformation of `TF_ENU0`. Independently from the original source of these values, we do not really need and use these transformations as we rely on the sole odometry msg. 

We propose to introduce a flag that controls wheter to also publish odometry in the form of a `TF2` transformation over ROS.  