### PR TITLE
Ignore tf messages with invalid quaternion

### DIFF
--- a/fixposition_driver_ros2/src/fixposition_driver_node.cpp
+++ b/fixposition_driver_ros2/src/fixposition_driver_node.cpp
@@ -145,6 +145,11 @@ void FixpositionDriverNode::RegisterObservers() {
         } else if (format == "TF") {
             dynamic_cast<NmeaConverter<FP_TF>*>(a_converters_["TF"].get())->AddObserver([this](const FP_TF& data) {
                 if (data.valid_tf) {
+                    // Ensure rotation is a valid quaternion
+                    if (data.tf.rotation.vec().isZero() && (data.tf.rotation.w() == 0)) {
+                        return;
+                    }
+
                     // TF Observer Lambda
                     geometry_msgs::msg::TransformStamped tf;
                     TfDataToMsg(data.tf, tf);


### PR DESCRIPTION
A TF message with rotation `0 0 0 0` will be accepted and send by the fixposition ros driver when no gnss signal is acquired. When using the (python) TransformListener in a node, this will continuously throw the following error messages:
`Error:   TF_NAN_INPUT: Ignoring transform for child_frame_id "FP_ENU0" from authority "default_authority" because of a nan value in the transform (0.000000 0.000000 0.000000) (nan nan nan nan)`.