### PR TITLE
Switch back from base_link to vrtk_link

### DIFF
--- a/fixposition_driver_ros2/include/fixposition_driver_ros2/data_to_ros2.hpp
+++ b/fixposition_driver_ros2/include/fixposition_driver_ros2/data_to_ros2.hpp
@@ -36,7 +36,7 @@ void OdometryDataToTransformStamped(const OdometryData& data, geometry_msgs::msg
 
 void PublishFpaOdometry(const fpsdk::common::parser::fpa::FpaOdometryPayload& payload,
                         rclcpp::Publisher<fpmsgs::FpaOdometry>::SharedPtr& pub);
-void PublishFpaOdometryDataImu(const fpsdk::common::parser::fpa::FpaOdometryPayload& payload, bool nav2_mode_,
+void PublishFpaOdometryDataImu(const fpsdk::common::parser::fpa::FpaOdomenuPayload& payload, bool nav2_mode_,
                                rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr& pub);
 void PublishFpaOdometryDataNavSatFix(const fpsdk::common::parser::fpa::FpaOdometryPayload& payload, bool nav2_mode_,
                                      rclcpp::Publisher<sensor_msgs::msg::NavSatFix>::SharedPtr& pub);

--- a/fixposition_driver_ros2/src/data_to_ros2.cpp
+++ b/fixposition_driver_ros2/src/data_to_ros2.cpp
@@ -147,7 +147,7 @@ void PublishFpaOdometryDataImu(const fpa::FpaOdomenuPayload& payload, bool nav2_
         }
         sensor_msgs::msg::Imu msg;
         msg.header.stamp = ros2::utils::ConvTime(FpaGpsTimeToTime(payload.gps_time));
-        msg.header.frame_id = nav2_mode_ ? "base_link" : ODOMETRY_FRAME_ID;
+        msg.header.frame_id = nav2_mode_ ? "vrtk_link" : ODOMETRY_FRAME_ID;
 
         // Orientation quaternion
         const Eigen::Quaterniond quat = {payload.orientation.values[0], payload.orientation.values[1],
@@ -218,7 +218,7 @@ void PublishFpaOdometryDataNavSatFix(const fpa::FpaOdometryPayload& payload, boo
         sensor_msgs::msg::NavSatFix msg;
         msg.header.stamp = ros2::utils::ConvTime(FpaGpsTimeToTime(payload.gps_time));
         if (nav2_mode_) {
-            msg.header.frame_id = "base_link";
+            msg.header.frame_id = "vrtk_link";
         } else {
             msg.header.frame_id = ODOMETRY_CHILD_FRAME_ID;
         }

--- a/fixposition_driver_ros2/src/data_to_ros2.cpp
+++ b/fixposition_driver_ros2/src/data_to_ros2.cpp
@@ -142,7 +142,9 @@ void PublishFpaOdometryDataImu(const fpa::FpaOdomenuPayload& payload, bool nav2_
         if (!payload.orientation.valid || !payload.acc.valid || !payload.rot.valid) {
             return;
         }
-
+        if (payload.gnss1_fix != fpa::FpaGnssFix::RTK_FIXED || payload.gnss2_fix != fpa::FpaGnssFix::RTK_FIXED) {
+            return;
+        }
         sensor_msgs::msg::Imu msg;
         msg.header.stamp = ros2::utils::ConvTime(FpaGpsTimeToTime(payload.gps_time));
         msg.header.frame_id = nav2_mode_ ? "base_link" : ODOMETRY_FRAME_ID;
@@ -251,7 +253,9 @@ void PublishFpaOdometryDataNavSatFix(const fpa::FpaOdometryPayload& payload, boo
                                       msg.status.SERVICE_GALILEO);
             }
         }
-
+        if (payload.gnss1_fix != fpa::FpaGnssFix::RTK_FIXED || payload.gnss2_fix != fpa::FpaGnssFix::RTK_FIXED) {
+            return;
+        }
         // Publish message
         pub->publish(msg);
     }

--- a/fixposition_driver_ros2/src/data_to_ros2.cpp
+++ b/fixposition_driver_ros2/src/data_to_ros2.cpp
@@ -148,10 +148,8 @@ void PublishFpaOdometryDataImu(const fpa::FpaOdomenuPayload& payload, bool nav2_
         msg.header.frame_id = nav2_mode_ ? "base_link" : ODOMETRY_FRAME_ID;
 
         // Orientation quaternion
-        // payload.orientation.values is [W, X, Y, Z]
-        // Eigen::Quaterniond initializer list is {x, y, z, w}
-        const Eigen::Quaterniond quat = {payload.orientation.values[1], payload.orientation.values[2],
-                                         payload.orientation.values[3], payload.orientation.values[0]};
+        const Eigen::Quaterniond quat = {payload.orientation.values[0], payload.orientation.values[1],
+                                         payload.orientation.values[2], payload.orientation.values[3]};
         msg.orientation = tf2::toMsg(quat);
 
         // Angular velocity and acceleration in body frame

--- a/fixposition_driver_ros2/src/data_to_ros2.cpp
+++ b/fixposition_driver_ros2/src/data_to_ros2.cpp
@@ -145,7 +145,7 @@ void PublishFpaOdometryDataImu(const fpa::FpaOdomenuPayload& payload, bool nav2_
 
         sensor_msgs::msg::Imu msg;
         msg.header.stamp = ros2::utils::ConvTime(FpaGpsTimeToTime(payload.gps_time));
-        msg.header.frame_id = nav2_mode_ ? "vrtk_link" : ODOMETRY_FRAME_ID;
+        msg.header.frame_id = nav2_mode_ ? "base_link" : ODOMETRY_FRAME_ID;
 
         // Orientation quaternion
         const Eigen::Quaterniond quat = {payload.orientation.values[0], payload.orientation.values[1],
@@ -216,7 +216,7 @@ void PublishFpaOdometryDataNavSatFix(const fpa::FpaOdometryPayload& payload, boo
         sensor_msgs::msg::NavSatFix msg;
         msg.header.stamp = ros2::utils::ConvTime(FpaGpsTimeToTime(payload.gps_time));
         if (nav2_mode_) {
-            msg.header.frame_id = "vrtk_link";
+            msg.header.frame_id = "base_link";
         } else {
             msg.header.frame_id = ODOMETRY_CHILD_FRAME_ID;
         }

--- a/fixposition_driver_ros2/src/data_to_ros2.cpp
+++ b/fixposition_driver_ros2/src/data_to_ros2.cpp
@@ -138,15 +138,108 @@ void PublishFpaOdomsh(const fpa::FpaOdomshPayload& payload, rclcpp::Publisher<fp
 void PublishFpaOdometryDataImu(const fpa::FpaOdometryPayload& payload, bool nav2_mode_,
                                rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr& pub) {
     if (pub->get_subscription_count() > 0) {
+        // Only publish if data is valid
+        if (!payload.orientation.valid || !payload.acc.valid || !payload.rot.valid) {
+            return;
+        }
+        
         sensor_msgs::msg::Imu msg;
         msg.header.stamp = ros2::utils::ConvTime(FpaGpsTimeToTime(payload.gps_time));
         if (nav2_mode_) {
-            msg.header.frame_id = "vrtk_link";
+            msg.header.frame_id = "base_link";
         } else {
-            msg.header.frame_id = ODOMETRY_FRAME_ID;
+            msg.header.frame_id = ODOMETRY_FRAME_ID;  // FP_POI frame
         }
-        FpaFloat3ToVector3(payload.acc, msg.linear_acceleration);
+        
+        // NOTE: Mixed reference frames for navsat_transform_node compatibility:
+        // - Orientation: Earth-referenced (ECEF) frame - what navsat_transform needs
+        // - Angular velocity & acceleration: Body (POI) frame - navsat_transform ignores these
+        // This is intentional as navsat_transform only uses orientation and handles frame transforms via TF
+        
+        // Orientation from payload (earth-referenced frame for navsat_transform compatibility)
+        msg.orientation.w = payload.orientation.values[0];
+        msg.orientation.x = payload.orientation.values[1];
+        msg.orientation.y = payload.orientation.values[2];
+        msg.orientation.z = payload.orientation.values[3];
+        
+        // Angular velocity and acceleration in body frame (navsat_transform doesn't use these)
         FpaFloat3ToVector3(payload.rot, msg.angular_velocity);
+        FpaFloat3ToVector3(payload.acc, msg.linear_acceleration);
+        
+        // Fill covariance matrices
+        // Orientation covariance (3x3 in row-major order)
+        if (payload.orientation_cov.valid) {
+            Eigen::Matrix3d ori_cov = BuildCovMat3D(
+                payload.orientation_cov.values[0], payload.orientation_cov.values[1], 
+                payload.orientation_cov.values[2], payload.orientation_cov.values[3], 
+                payload.orientation_cov.values[4], payload.orientation_cov.values[5]);
+            
+            for (int i = 0; i < 3; ++i) {
+                for (int j = 0; j < 3; ++j) {
+                    msg.orientation_covariance[i * 3 + j] = ori_cov(i, j);
+                }
+            }
+        } else {
+            // Set unknown covariance
+            std::fill(msg.orientation_covariance.begin(), msg.orientation_covariance.end(), -1.0);
+        }
+        
+        // Linear acceleration covariance - use velocity covariance as a proxy if available
+        if (payload.vel_cov.valid) {
+            // Use velocity covariance as a reasonable proxy for acceleration noise
+            // Scale by approximate factor to convert from velocity to acceleration covariance
+            Eigen::Matrix3d vel_cov = BuildCovMat3D(
+                payload.vel_cov.values[0], payload.vel_cov.values[1], 
+                payload.vel_cov.values[2], payload.vel_cov.values[3], 
+                payload.vel_cov.values[4], payload.vel_cov.values[5]);
+            
+            // Scale velocity covariance to get approximate acceleration covariance
+            // Assuming acceleration noise is related to velocity noise / time_constant
+            const double accel_scale_factor = 0.1; // Heuristic scaling factor
+            Eigen::Matrix3d acc_cov = vel_cov * accel_scale_factor;
+            
+            std::fill(msg.linear_acceleration_covariance.begin(), msg.linear_acceleration_covariance.end(), 0.0);
+            for (int i = 0; i < 3; ++i) {
+                for (int j = 0; j < 3; ++j) {
+                    msg.linear_acceleration_covariance[i * 3 + j] = acc_cov(i, j);
+                }
+            }
+        } else {
+            // Use reasonable default values based on typical IMU performance
+            std::fill(msg.linear_acceleration_covariance.begin(), msg.linear_acceleration_covariance.end(), 0.0);
+            msg.linear_acceleration_covariance[0] = 0.01;  // x variance (m/s²)²
+            msg.linear_acceleration_covariance[4] = 0.01;  // y variance
+            msg.linear_acceleration_covariance[8] = 0.01;  // z variance
+        }
+        
+        // Angular velocity covariance - use orientation covariance as a proxy if available
+        if (payload.orientation_cov.valid) {
+            // Use orientation covariance as a proxy for angular velocity noise
+            // Scale by approximate factor to convert from orientation to angular velocity covariance
+            Eigen::Matrix3d ori_cov = BuildCovMat3D(
+                payload.orientation_cov.values[0], payload.orientation_cov.values[1], 
+                payload.orientation_cov.values[2], payload.orientation_cov.values[3], 
+                payload.orientation_cov.values[4], payload.orientation_cov.values[5]);
+            
+            // Scale orientation covariance to get approximate angular velocity covariance
+            // Assuming angular velocity noise is related to orientation uncertainty / time_constant
+            const double angular_vel_scale_factor = 0.01; // Heuristic scaling factor
+            Eigen::Matrix3d angular_vel_cov = ori_cov * angular_vel_scale_factor;
+            
+            std::fill(msg.angular_velocity_covariance.begin(), msg.angular_velocity_covariance.end(), 0.0);
+            for (int i = 0; i < 3; ++i) {
+                for (int j = 0; j < 3; ++j) {
+                    msg.angular_velocity_covariance[i * 3 + j] = angular_vel_cov(i, j);
+                }
+            }
+        } else {
+            // Use reasonable default values based on typical IMU performance
+            std::fill(msg.angular_velocity_covariance.begin(), msg.angular_velocity_covariance.end(), 0.0);
+            msg.angular_velocity_covariance[0] = 0.001;  // x variance (rad/s)²
+            msg.angular_velocity_covariance[4] = 0.001;  // y variance
+            msg.angular_velocity_covariance[8] = 0.001;  // z variance
+        }
+        
         pub->publish(msg);
     }
 }

--- a/fixposition_driver_ros2/src/data_to_ros2.cpp
+++ b/fixposition_driver_ros2/src/data_to_ros2.cpp
@@ -244,7 +244,7 @@ void PublishFpaOdometryDataNavSatFix(const fpa::FpaOdometryPayload& payload, boo
         sensor_msgs::msg::NavSatFix msg;
         msg.header.stamp = ros2::utils::ConvTime(FpaGpsTimeToTime(payload.gps_time));
         if (nav2_mode_) {
-            msg.header.frame_id = "vrtk_link";
+            msg.header.frame_id = "base_link";
         } else {
             msg.header.frame_id = ODOMETRY_CHILD_FRAME_ID;
         }

--- a/fixposition_driver_ros2/src/data_to_ros2.cpp
+++ b/fixposition_driver_ros2/src/data_to_ros2.cpp
@@ -147,15 +147,13 @@ void PublishFpaOdometryDataImu(const fpa::FpaOdometryPayload& payload, bool nav2
         msg.header.stamp = ros2::utils::ConvTime(FpaGpsTimeToTime(payload.gps_time));
         msg.header.frame_id = nav2_mode_ ? "base_link" : ODOMETRY_FRAME_ID;
 
-        tf2::Quaternion tfq(
-            payload.orientation.values[3],  // w
-            payload.orientation.values[0],  // x
-            payload.orientation.values[1],  // y
-            payload.orientation.values[2]   // z
+        tf2::Quaternion tfq(payload.orientation.values[0],  // x
+                            payload.orientation.values[1],  // y
+                            payload.orientation.values[2],  // z
+                            payload.orientation.values[3]   // w
         );
         // This quaternion already represents the rotation between ENU and FP_POI
         msg.orientation = tf2::toMsg(tfq);
-
 
         // Angular velocity and acceleration in body frame
         FpaFloat3ToVector3(payload.rot, msg.angular_velocity);

--- a/fixposition_driver_ros2/src/data_to_ros2.cpp
+++ b/fixposition_driver_ros2/src/data_to_ros2.cpp
@@ -148,8 +148,10 @@ void PublishFpaOdometryDataImu(const fpa::FpaOdometryPayload& payload, bool nav2
         msg.header.frame_id = nav2_mode_ ? "base_link" : ODOMETRY_FRAME_ID;
 
         // Orientation quaternion
-        const Eigen::Quaterniond quat = {payload.orientation.values[0], payload.orientation.values[1],
-                                         payload.orientation.values[2], payload.orientation.values[3]};
+        // payload.orientation.values is [W, X, Y, Z]
+        // Eigen::Quaterniond initializer list is {x, y, z, w}
+        const Eigen::Quaterniond quat = {payload.orientation.values[1], payload.orientation.values[2],
+                                         payload.orientation.values[3], payload.orientation.values[0]};
         msg.orientation = tf2::toMsg(quat);
 
         // Angular velocity and acceleration in body frame

--- a/fixposition_driver_ros2/src/data_to_ros2.cpp
+++ b/fixposition_driver_ros2/src/data_to_ros2.cpp
@@ -135,7 +135,7 @@ void PublishFpaOdomsh(const fpa::FpaOdomshPayload& payload, rclcpp::Publisher<fp
 
 // ---------------------------------------------------------------------------------------------------------------------
 
-void PublishFpaOdometryDataImu(const fpa::FpaOdometryPayload& payload, bool nav2_mode_,
+void PublishFpaOdometryDataImu(const fpa::FpaOdomenuPayload& payload, bool nav2_mode_,
                                rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr& pub) {
     if (pub->get_subscription_count() > 0) {
         // Only publish if data is valid

--- a/fixposition_driver_ros2/src/data_to_ros2.cpp
+++ b/fixposition_driver_ros2/src/data_to_ros2.cpp
@@ -147,13 +147,10 @@ void PublishFpaOdometryDataImu(const fpa::FpaOdometryPayload& payload, bool nav2
         msg.header.stamp = ros2::utils::ConvTime(FpaGpsTimeToTime(payload.gps_time));
         msg.header.frame_id = nav2_mode_ ? "base_link" : ODOMETRY_FRAME_ID;
 
-        tf2::Quaternion tfq(payload.orientation.values[0],  // x
-                            payload.orientation.values[1],  // y
-                            payload.orientation.values[2],  // z
-                            payload.orientation.values[3]   // w
-        );
-        // This quaternion already represents the rotation between ENU and FP_POI
-        msg.orientation = tf2::toMsg(tfq);
+        // Orientation quaternion
+        const Eigen::Quaterniond quat = {payload.orientation.values[0], payload.orientation.values[1],
+                                         payload.orientation.values[2], payload.orientation.values[3]};
+        msg.orientation = tf2::toMsg(quat);
 
         // Angular velocity and acceleration in body frame
         FpaFloat3ToVector3(payload.rot, msg.angular_velocity);

--- a/fixposition_driver_ros2/src/data_to_ros2.cpp
+++ b/fixposition_driver_ros2/src/data_to_ros2.cpp
@@ -145,7 +145,7 @@ void PublishFpaOdometryDataImu(const fpa::FpaOdomenuPayload& payload, bool nav2_
 
         sensor_msgs::msg::Imu msg;
         msg.header.stamp = ros2::utils::ConvTime(FpaGpsTimeToTime(payload.gps_time));
-        msg.header.frame_id = nav2_mode_ ? "base_link" : ODOMETRY_FRAME_ID;
+        msg.header.frame_id = nav2_mode_ ? "vrtk_link" : ODOMETRY_FRAME_ID;
 
         // Orientation quaternion
         const Eigen::Quaterniond quat = {payload.orientation.values[0], payload.orientation.values[1],

--- a/fixposition_driver_ros2/src/data_to_ros2.cpp
+++ b/fixposition_driver_ros2/src/data_to_ros2.cpp
@@ -147,13 +147,15 @@ void PublishFpaOdometryDataImu(const fpa::FpaOdometryPayload& payload, bool nav2
         msg.header.stamp = ros2::utils::ConvTime(FpaGpsTimeToTime(payload.gps_time));
         msg.header.frame_id = nav2_mode_ ? "base_link" : ODOMETRY_FRAME_ID;
 
-        // Build quaternion from payload [x, y, z, w] using tf2 (x,y,z,w)
-        tf2::Quaternion tfq(payload.orientation.values[0],  // x
-                            payload.orientation.values[1],  // y
-                            payload.orientation.values[2],  // z
-                            payload.orientation.values[3]   // w
+        tf2::Quaternion tfq(
+            payload.orientation.values[3],  // w
+            payload.orientation.values[0],  // x
+            payload.orientation.values[1],  // y
+            payload.orientation.values[2]   // z
         );
+        // This quaternion already represents the rotation between ENU and FP_POI
         msg.orientation = tf2::toMsg(tfq);
+
 
         // Angular velocity and acceleration in body frame
         FpaFloat3ToVector3(payload.rot, msg.angular_velocity);

--- a/fixposition_driver_ros2/src/fixposition_driver_node.cpp
+++ b/fixposition_driver_ros2/src/fixposition_driver_node.cpp
@@ -727,7 +727,7 @@ void FixpositionDriverNode::PublishNav2Tf() {
     geometry_msgs::msg::TransformStamped tf_odom_base;
     tf_odom_base.header.stamp = tfs_.enu0_poi_->header.stamp;
     tf_odom_base.header.frame_id = "odom";
-    tf_odom_base.child_frame_id = "base_link";
+    tf_odom_base.child_frame_id = "vrtk_link";
     tf_odom_base.transform = tf2::toMsg(tf_ENU0POISH);
     // tf_br_->sendTransform(tf_odom_base);
 

--- a/fixposition_driver_ros2/src/fixposition_driver_node.cpp
+++ b/fixposition_driver_ros2/src/fixposition_driver_node.cpp
@@ -664,18 +664,18 @@ void FixpositionDriverNode::PublishNav2Tf() {
     }
 
     // Publish a static identity transform from FP_ENU0 to map
-    // geometry_msgs::msg::TransformStamped static_transform;
-    // static_transform.header.stamp = tfs_.ecef_enu0_->header.stamp;
-    // static_transform.header.frame_id = "FP_ENU0";
-    // static_transform.child_frame_id = "map";
-    // static_transform.transform.translation.x = 0.0;
-    // static_transform.transform.translation.y = 0.0;
-    // static_transform.transform.translation.z = 0.0;
-    // static_transform.transform.rotation.w = 1.0;
-    // static_transform.transform.rotation.x = 0.0;
-    // static_transform.transform.rotation.y = 0.0;
-    // static_transform.transform.rotation.z = 0.0;
-    // static_br_->sendTransform(static_transform);
+    geometry_msgs::msg::TransformStamped static_transform;
+    static_transform.header.stamp = tfs_.ecef_enu0_->header.stamp;
+    static_transform.header.frame_id = "FP_ENU0";
+    static_transform.child_frame_id = "map";
+    static_transform.transform.translation.x = 0.0;
+    static_transform.transform.translation.y = 0.0;
+    static_transform.transform.translation.z = 0.0;
+    static_transform.transform.rotation.w = 1.0;
+    static_transform.transform.rotation.x = 0.0;
+    static_transform.transform.rotation.y = 0.0;
+    static_transform.transform.rotation.z = 0.0;
+    static_br_->sendTransform(static_transform);
 
     // Compute FP_ENU0 -> FP_POISH
     // Extract translation and rotation from ECEFENU0

--- a/fixposition_driver_ros2/src/fixposition_driver_node.cpp
+++ b/fixposition_driver_ros2/src/fixposition_driver_node.cpp
@@ -664,18 +664,18 @@ void FixpositionDriverNode::PublishNav2Tf() {
     }
 
     // Publish a static identity transform from FP_ENU0 to map
-    geometry_msgs::msg::TransformStamped static_transform;
-    static_transform.header.stamp = tfs_.ecef_enu0_->header.stamp;
-    static_transform.header.frame_id = "FP_ENU0";
-    static_transform.child_frame_id = "map";
-    static_transform.transform.translation.x = 0.0;
-    static_transform.transform.translation.y = 0.0;
-    static_transform.transform.translation.z = 0.0;
-    static_transform.transform.rotation.w = 1.0;
-    static_transform.transform.rotation.x = 0.0;
-    static_transform.transform.rotation.y = 0.0;
-    static_transform.transform.rotation.z = 0.0;
-    static_br_->sendTransform(static_transform);
+    // geometry_msgs::msg::TransformStamped static_transform;
+    // static_transform.header.stamp = tfs_.ecef_enu0_->header.stamp;
+    // static_transform.header.frame_id = "FP_ENU0";
+    // static_transform.child_frame_id = "map";
+    // static_transform.transform.translation.x = 0.0;
+    // static_transform.transform.translation.y = 0.0;
+    // static_transform.transform.translation.z = 0.0;
+    // static_transform.transform.rotation.w = 1.0;
+    // static_transform.transform.rotation.x = 0.0;
+    // static_transform.transform.rotation.y = 0.0;
+    // static_transform.transform.rotation.z = 0.0;
+    // static_br_->sendTransform(static_transform);
 
     // Compute FP_ENU0 -> FP_POISH
     // Extract translation and rotation from ECEFENU0
@@ -714,7 +714,7 @@ void FixpositionDriverNode::PublishNav2Tf() {
     tfs_odom.header.frame_id = "map";
     tfs_odom.child_frame_id = "odom";
     tfs_odom.transform = tf2::toMsg(tf_combined);
-    tf_br_->sendTransform(tfs_odom);
+    // tf_br_->sendTransform(tfs_odom);
 
     // Publish odom -> vrtk_link
     geometry_msgs::msg::TransformStamped tf_odom_base;
@@ -722,7 +722,7 @@ void FixpositionDriverNode::PublishNav2Tf() {
     tf_odom_base.header.frame_id = "odom";
     tf_odom_base.child_frame_id = "vrtk_link";
     tf_odom_base.transform = tf2::toMsg(tf_ENU0POISH);
-    tf_br_->sendTransform(tf_odom_base);
+    // tf_br_->sendTransform(tf_odom_base);
 
     // Publish WGS84 datum
     PublishDatum(trans_ecef_enu0, tfs_.enu0_poi_->header.stamp, datum_pub_);

--- a/fixposition_driver_ros2/src/fixposition_driver_node.cpp
+++ b/fixposition_driver_ros2/src/fixposition_driver_node.cpp
@@ -155,6 +155,7 @@ bool FixpositionDriverNode::StartNode() {
             auto odomenu_payload = dynamic_cast<const fpa::FpaOdomenuPayload&>(payload);
             PublishFpaOdomenu(odomenu_payload, fpa_odomenu_pub_);
             PublishFpaOdomenuVector3Stamped(odomenu_payload, eul_pub_);
+
             OdometryData odometry_data;
             odometry_data.SetFromFpaOdomPayload(odomenu_payload);
 
@@ -666,18 +667,18 @@ void FixpositionDriverNode::PublishNav2Tf() {
     }
 
     // Publish a static identity transform from FP_ENU0 to map
-    geometry_msgs::msg::TransformStamped static_transform;
-    static_transform.header.stamp = tfs_.ecef_enu0_->header.stamp;
-    static_transform.header.frame_id = "FP_ENU0";
-    static_transform.child_frame_id = "map";
-    static_transform.transform.translation.x = 0.0;
-    static_transform.transform.translation.y = 0.0;
-    static_transform.transform.translation.z = 0.0;
-    static_transform.transform.rotation.w = 1.0;
-    static_transform.transform.rotation.x = 0.0;
-    static_transform.transform.rotation.y = 0.0;
-    static_transform.transform.rotation.z = 0.0;
-    static_br_->sendTransform(static_transform);
+    // geometry_msgs::msg::TransformStamped static_transform;
+    // static_transform.header.stamp = tfs_.ecef_enu0_->header.stamp;
+    // static_transform.header.frame_id = "FP_ENU0";
+    // static_transform.child_frame_id = "map";
+    // static_transform.transform.translation.x = 0.0;
+    // static_transform.transform.translation.y = 0.0;
+    // static_transform.transform.translation.z = 0.0;
+    // static_transform.transform.rotation.w = 1.0;
+    // static_transform.transform.rotation.x = 0.0;
+    // static_transform.transform.rotation.y = 0.0;
+    // static_transform.transform.rotation.z = 0.0;
+    // static_br_->sendTransform(static_transform);
 
     // Compute FP_ENU0 -> FP_POISH
     // Extract translation and rotation from ECEFENU0

--- a/fixposition_driver_ros2/src/fixposition_driver_node.cpp
+++ b/fixposition_driver_ros2/src/fixposition_driver_node.cpp
@@ -164,7 +164,9 @@ bool FixpositionDriverNode::StartNode() {
                 odometry_data.child_frame_id = "vrtk_link";
             }
 
-            PublishOdometryData(odometry_data, odometry_enu_pub_);
+            if (odometry_data.valid) {
+                PublishOdometryData(odometry_data, odometry_enu_pub_);
+            }
             ProcessOdometryData(odometry_data);
             fusion_epoch_data_.CollectFpaOdomenu(odomenu_payload);
         });

--- a/fixposition_driver_ros2/src/fixposition_driver_node.cpp
+++ b/fixposition_driver_ros2/src/fixposition_driver_node.cpp
@@ -129,7 +129,7 @@ bool FixpositionDriverNode::StartNode() {
             // Update frames for Nav2
             if (params_.nav2_mode_) {
                 odometry_data.frame_id = "odom";
-                odometry_data.child_frame_id = "base_link";
+                odometry_data.child_frame_id = "vrtk_link";
             }
 
             PublishOdometryData(odometry_data, odometry_smooth_pub_);
@@ -161,7 +161,7 @@ bool FixpositionDriverNode::StartNode() {
             // Update frames for Nav2
             if (params_.nav2_mode_) {
                 odometry_data.frame_id = "map";
-                odometry_data.child_frame_id = "base_link";
+                odometry_data.child_frame_id = "vrtk_link";
             }
 
             PublishOdometryData(odometry_data, odometry_enu_pub_);

--- a/fixposition_driver_ros2/src/fixposition_driver_node.cpp
+++ b/fixposition_driver_ros2/src/fixposition_driver_node.cpp
@@ -101,11 +101,11 @@ bool FixpositionDriverNode::StartNode() {
         _PUB(fpa_odometry_pub_, fpmsgs::FpaOdometry, output_ns + "/fpa/odometry", qos_settings_);
         _PUB(odometry_ecef_pub_, nav_msgs::msg::Odometry, output_ns + "/odometry_ecef", qos_settings_);
         _PUB(odometry_llh_pub_, sensor_msgs::msg::NavSatFix, output_ns + "/odometry_llh", qos_settings_);
-        _PUB(poiimu_pub_, sensor_msgs::msg::Imu, output_ns + "/poiimu", qos_settings_);
+        // Remove poiimu_pub_ from here since it's now published from ODOMENU
         driver_.AddFpaObserver(fpa::FpaOdometryPayload::MSG_NAME, [this](const fpa::FpaPayload& payload) {
             auto odometry_payload = dynamic_cast<const fpa::FpaOdometryPayload&>(payload);
             PublishFpaOdometry(odometry_payload, fpa_odometry_pub_);
-            PublishFpaOdometryDataImu(odometry_payload, params_.nav2_mode_, poiimu_pub_);
+            // Remove PublishFpaOdometryDataImu call from here
             PublishFpaOdometryDataNavSatFix(odometry_payload, params_.nav2_mode_, odometry_llh_pub_);
             OdometryData odometry_data;
             odometry_data.SetFromFpaOdomPayload(odometry_payload);
@@ -151,10 +151,14 @@ bool FixpositionDriverNode::StartNode() {
         _PUB(fpa_odomenu_pub_, fpmsgs::FpaOdomenu, output_ns + "/fpa/odomenu", qos_settings_);
         _PUB(odometry_enu_pub_, nav_msgs::msg::Odometry, output_ns + "/odometry_enu", qos_settings_);
         _PUB(eul_pub_, geometry_msgs::msg::Vector3Stamped, output_ns + "/ypr", qos_settings_);
+        _PUB(poiimu_pub_, sensor_msgs::msg::Imu, output_ns + "/poiimu", qos_settings_);
         driver_.AddFpaObserver(fpa::FpaOdomenuPayload::MSG_NAME, [this](const fpa::FpaPayload& payload) {
             auto odomenu_payload = dynamic_cast<const fpa::FpaOdomenuPayload&>(payload);
             PublishFpaOdomenu(odomenu_payload, fpa_odomenu_pub_);
             PublishFpaOdomenuVector3Stamped(odomenu_payload, eul_pub_);
+            
+            // Add IMU publishing from the same ENU payload
+            PublishFpaOdometryDataImu(odomenu_payload, params_.nav2_mode_, poiimu_pub_);
 
             OdometryData odometry_data;
             odometry_data.SetFromFpaOdomPayload(odomenu_payload);

--- a/fixposition_driver_ros2/src/fixposition_driver_node.cpp
+++ b/fixposition_driver_ros2/src/fixposition_driver_node.cpp
@@ -129,7 +129,7 @@ bool FixpositionDriverNode::StartNode() {
             // Update frames for Nav2
             if (params_.nav2_mode_) {
                 odometry_data.frame_id = "odom";
-                odometry_data.child_frame_id = "vrtk_link";
+                odometry_data.child_frame_id = "base_link";
             }
 
             PublishOdometryData(odometry_data, odometry_smooth_pub_);
@@ -161,7 +161,7 @@ bool FixpositionDriverNode::StartNode() {
             // Update frames for Nav2
             if (params_.nav2_mode_) {
                 odometry_data.frame_id = "map";
-                odometry_data.child_frame_id = "vrtk_link";
+                odometry_data.child_frame_id = "base_link";
             }
 
             PublishOdometryData(odometry_data, odometry_enu_pub_);
@@ -720,7 +720,7 @@ void FixpositionDriverNode::PublishNav2Tf() {
     geometry_msgs::msg::TransformStamped tf_odom_base;
     tf_odom_base.header.stamp = tfs_.enu0_poi_->header.stamp;
     tf_odom_base.header.frame_id = "odom";
-    tf_odom_base.child_frame_id = "vrtk_link";
+    tf_odom_base.child_frame_id = "base_link";
     tf_odom_base.transform = tf2::toMsg(tf_ENU0POISH);
     // tf_br_->sendTransform(tf_odom_base);
 


### PR DESCRIPTION
We remove the output transformation applied by the Fixposition so the data received is not in `base_link`.
We make sure all data received from the sensor is in the sensor link and we apply the transformation on the robot.