### PR TITLE
Parameterize config directory

### DIFF
--- a/fixposition_driver_ros2/launch/node.launch
+++ b/fixposition_driver_ros2/launch/node.launch
@@ -2,11 +2,12 @@
 <launch>
     <arg name="node_name"   default="fixposition_driver_ros2" description="Node name"/> <!--  -->
     <arg name="config"      default="config.yaml"             description="Configuration file to use"/>
+    <arg name="config_dir"  default="$(find-pkg-share fixposition_driver_ros2)/launch"/>
     <arg name="launcher"    default=""                        description="Launch node via this (node launch-prefix)"/>
     <node name="$(var node_name)" pkg="fixposition_driver_ros2" exec="fixposition_driver_ros2_exec"
         output="screen" respawn="true" respawn_delay="5" launch-prefix="$(var launcher)"
         ros_args="--log-level $(var node_name):=info">
-        <param from="$(find-pkg-share fixposition_driver_ros2)/launch/$(var config)"/>
+        <param from="$(var config_dir)/$(var config)"/>
         <param name="some_numeric_param" value="100.2"/>
     </node>
 </launch>


### PR DESCRIPTION
This PR enables users to provide config files at locations of their choosing instead of the hard-coded config path at 'fixposition_driver_ros2/launch'.