### PR TITLE
Fix automatic reconnect

### DIFF
--- a/fixposition_driver_lib/src/fixposition_driver.cpp
+++ b/fixposition_driver_lib/src/fixposition_driver.cpp
@@ -84,7 +84,6 @@ void FixpositionDriver::Disconnect() {
             DisconnectTcp();
         }
         sensor_fd_ = -1;
-        params_.stream_.clear();
     }
 }
 


### PR DESCRIPTION
Re-connect is broken because the stream spec is cleared on disconnect. By removing the 'clear' statement, subsequent reconnect attempts will work.
