### PR TITLE
fix Lyrical build and CI

### DIFF
--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -150,13 +150,13 @@ function build_colcon_release_clang
     local buildname=${FPSDK_IMAGE}_build_colcon_release_clang
     ${FP_SRC_DIR}/create_ros_ws.sh ${buildname} || return 1
     cd ${FP_SRC_DIR}/${buildname}
-    export CC=clang CXX=clang++
-    colcon build || return 1
+    colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release \
+        -DFPSDK_BUILD_TESTING=OFF -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
+        || return 1
     set +u
     source install/setup.bash
     set -u
     ros2 pkg executables fixposition_driver_ros2
-    unset CC CXX
 }
 
 TITLES["build_colcon_debug_clang"]="Build colcon (debug, with ROS2, clang instead of GCC)"
@@ -165,13 +165,13 @@ function build_colcon_debug_clang
     local buildname=${FPSDK_IMAGE}_build_colcon_debug_clang
     ${FP_SRC_DIR}/create_ros_ws.sh -d ${buildname} || return 1
     cd ${FP_SRC_DIR}/${buildname}
-    export CC=clang CXX=clang++
-    colcon build || return 1
+    colcon build --cmake-args -DCMAKE_BUILD_TYPE=Debug \
+        -DFPSDK_BUILD_TESTING=OFF -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
+        || return 1
     set +u
     source install/setup.bash
     set -u
     ros2 pkg executables fixposition_driver_ros2
-    unset CC CXX
 }
 
 ########################################################################################################################

--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -189,7 +189,7 @@ if [ "${ROS_DISTRO}" = "noetic" ]; then
     do_step build_catkin_debug            || true # continue
 
 # ROS 2
-elif [ "${ROS_DISTRO}" = "humble" -o "${ROS_DISTRO}" = "jazzy" ]; then
+elif [ "${ROS_DISTRO}" = "humble" -o "${ROS_DISTRO}" = "jazzy" -o "${ROS_DISTRO}" = "lyrical" ]; then
     set +u
     source /opt/ros/${ROS_DISTRO}/setup.bash
     set -u

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
                 shell: bash
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                     submodules: 'recursive'
             - name: Build
@@ -36,7 +36,7 @@ jobs:
                 shell: bash
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                     submodules: 'recursive'
             - name: Build
@@ -53,7 +53,7 @@ jobs:
                 shell: bash
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                     submodules: 'recursive'
             - name: Build
@@ -70,7 +70,7 @@ jobs:
                 shell: bash
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                     submodules: 'recursive'
             - name: Build

--- a/fixposition_driver_lib/CMakeLists.txt
+++ b/fixposition_driver_lib/CMakeLists.txt
@@ -16,6 +16,8 @@ if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_compile_definitions(NDEBUG)
 endif()
 
+set(_unused "${FPSDK_BUILD_TESTING}") # suppress warning
+set(_unused "${CMAKE_C_COMPILER}") # suppress warning
 
 # DEPENDENCIES =========================================================================================================
 

--- a/fixposition_driver_msgs/CMakeLists.txt
+++ b/fixposition_driver_msgs/CMakeLists.txt
@@ -4,7 +4,8 @@ cmake_minimum_required(VERSION 3.16)
 project(fixposition_driver_msgs VERSION 8.0.0 LANGUAGES CXX C)
 
 set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Werror\
+# -Wno-invalid-offsetof warning in ROS IDL generated code. Not something we can control...
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Werror -Wno-invalid-offsetof \
     -Wshadow -Wunused-parameter -Wformat -Wpointer-arith -Woverloaded-virtual")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -14,6 +15,8 @@ endif()
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_compile_definitions(NDEBUG)
 endif()
+
+set(_unused "${FPSDK_BUILD_TESTING}") # suppress warning
 
 
 # DEPENDENCIES =========================================================================================================

--- a/fixposition_driver_msgs/msg/ParserMsg.msg
+++ b/fixposition_driver_msgs/msg/ParserMsg.msg
@@ -17,7 +17,7 @@ int8    PROTOCOL_SPARTN      =  8
 int8    PROTOCOL_OTHER       =  9
 int8    PROTOCOL_SBF         = 10
 int8    PROTOCOL_QGC         = 11
-uint8[] data                      # Message data
 string  name                      # Message name
 uint64  seq                       # Message counter
 string  info                      # Message (debug) info
+uint8[] data                      # Message data

--- a/fixposition_driver_ros1/CMakeLists.txt
+++ b/fixposition_driver_ros1/CMakeLists.txt
@@ -15,6 +15,8 @@ if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_compile_definitions(NDEBUG)
 endif()
 
+set(_unused "${FPSDK_BUILD_TESTING}") # suppress warning
+
 
 # DEPENDENCIES =========================================================================================================
 

--- a/fixposition_driver_ros2/CMakeLists.txt
+++ b/fixposition_driver_ros2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # GENERAL ==============================================================================================================
 cmake_minimum_required(VERSION 3.5)
 project(fixposition_driver_ros2)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE "Release")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Werror\
     -Wshadow -Wunused-parameter -Wformat -Wpointer-arith")
@@ -47,14 +47,24 @@ add_executable(
   src/data_to_ros2.cpp
 )
 
-target_link_libraries(
-  ${PROJECT_NAME}_exec
+target_link_libraries(${PROJECT_NAME}_exec
   ${fixposition_driver_lib_LIBRARIES}
   ${rtcm_msgs_LIBRARIES}
   ${Boost_LIBRARIES}
   ${EIGEN3_LIBRARIES}
   ${fpsdk_common_LIBRARIES} ${fpsdk_ros2_LIBRARIES}
   ${rosbag2_cpp_TARGETS}
+  ${rclcpp_TARGETS}
+  ${std_msgs_TARGETS}
+  ${nav_msgs_TARGETS}
+  ${geometry_msgs_TARGETS}
+  ${sensor_msgs_TARGETS}
+  ${tf2_ros_TARGETS}
+  ${tf2_eigen_TARGETS}
+  ${fixposition_driver_lib_TARGETS}
+  ${fixposition_driver_msgs_TARGETS}
+  ${rtcm_msgs_TARGETS}
+  ${tf2_geometry_msgs_TARGETS}
   pthread
 )
 
@@ -73,9 +83,6 @@ install(DIRECTORY
   "launch"
   DESTINATION share/${PROJECT_NAME}/
 )
-ament_target_dependencies(${PROJECT_NAME}_exec
-    rclcpp std_msgs nav_msgs geometry_msgs sensor_msgs tf2_ros tf2_eigen
-    fixposition_driver_lib fixposition_driver_msgs rtcm_msgs tf2_geometry_msgs)
 
 # define ament package for this project
 ament_package()

--- a/fixposition_driver_ros2/CMakeLists.txt
+++ b/fixposition_driver_ros2/CMakeLists.txt
@@ -1,5 +1,5 @@
 # GENERAL ==============================================================================================================
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 project(fixposition_driver_ros2)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE "Release")
@@ -7,6 +7,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Werror\
     -Wshadow -Wunused-parameter -Wformat -Wpointer-arith")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+set(_unused "${FPSDK_BUILD_TESTING}") # suppress warning
 
 # DEPENDENCIES =========================================================================================================
 find_package(Boost 1.65.0 REQUIRED COMPONENTS date_time)

--- a/fixposition_driver_ros2/include/fixposition_driver_ros2/ros2_msgs.hpp
+++ b/fixposition_driver_ros2/include/fixposition_driver_ros2/ros2_msgs.hpp
@@ -7,19 +7,18 @@
 #pragma GCC diagnostic ignored "-Wshadow"
 
 // Standard ROS messages
-#include <tf2/LinearMath/Transform.h>
-#include <tf2_ros/static_transform_broadcaster.h>
-#include <tf2_ros/transform_broadcaster.h>
-#include <tf2_ros/transform_listener.h>
-
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <geometry_msgs/msg/vector3_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 #include <sensor_msgs/msg/nav_sat_fix.hpp>
 #include <std_msgs/msg/u_int8_multi_array.hpp>
+#include <tf2/LinearMath/Transform.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#include <tf2_ros/static_transform_broadcaster.hpp>
+#include <tf2_ros/transform_broadcaster.hpp>
+#include <tf2_ros/transform_listener.hpp>
 
 // RTCM
 #include <rtcm_msgs/msg/message.hpp>

--- a/rtcm_msgs/CMakeLists.txt
+++ b/rtcm_msgs/CMakeLists.txt
@@ -1,5 +1,7 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 project(rtcm_msgs)
+
+set(_unused "${FPSDK_BUILD_TESTING}") # suppress warning
 
 # ros_environment is needed to have ROS_VERSION
 find_package(ros_environment REQUIRED)


### PR DESCRIPTION
Fixes for Lyrical:

- Update legacy .h header includes to .hpp
- Update cmake config (less "ament", more "cmake", but there is still way to go...)
- Rearrange ParserMsg.msg fields and silence warnings. It seems that Lyrical IDL generation has some bug and generates uncompilable code.. :-?

Other:

- Use cmake arguments to explicitly specify clang (for the clang builds)
- Silence some warnings due to colcon only supporting "top-level" cmake args, which are passed to all packages
- Update github actions/checkout version (silence warning)
