### PR TITLE
Fix TCP read capped at 8 bytes (sizeof pointer)

### DIFF
--- a/fixposition_driver_lib/src/fixposition_driver.cpp
+++ b/fixposition_driver_lib/src/fixposition_driver.cpp
@@ -208,7 +208,7 @@ std::size_t FixpositionDriver::Read(uint8_t* buf, const std::size_t size, const 
         if (serial_) {
             rv = recv(sensor_fd_, buf, size, MSG_DONTWAIT);
         } else {
-            rv = read(sensor_fd_, buf, sizeof(buf));
+            rv = read(sensor_fd_, buf, size);
         }
         // We have some data
         if (rv >= 0) {


### PR DESCRIPTION
In `FixpositionDriver::Read()`, the TCP branch calls `read(sensor_fd_, buf, sizeof(buf))`.

Since `buf` is a `uint8_t*` parameter, `sizeof(buf)` evaluates to the pointer size (8 bytes on 64-bit), not the buffer capacity carried by the `size` argument. As a result, every TCP read is capped at 8 bytes regardless of the buffer passed in.